### PR TITLE
Better clipping support

### DIFF
--- a/svgnative/include/SVGRenderer.h
+++ b/svgnative/include/SVGRenderer.h
@@ -162,12 +162,14 @@ public:
 
 struct ClippingPath
 {
-    ClippingPath(WindingRule aClipRule, std::shared_ptr<Path> aPath, std::shared_ptr<Transform> aTransform)
-        : clipRule{aClipRule}
+    ClippingPath(bool aHasClipContent, WindingRule aClipRule, std::shared_ptr<Path> aPath, std::shared_ptr<Transform> aTransform)
+        : hasClipContent{aHasClipContent}
+        , clipRule{aClipRule}
         , path{aPath}
         , transform{aTransform}
     {}
 
+    bool hasClipContent = false;
     WindingRule clipRule = WindingRule::kNonZero;
     std::shared_ptr<Path> path; /** Clipping path. **/
     std::shared_ptr<Transform> transform; /** Joined transformation matrix based to the "transform" attribute. **/

--- a/svgnative/include/SVGRenderer.h
+++ b/svgnative/include/SVGRenderer.h
@@ -160,6 +160,19 @@ public:
     virtual void Concat(const Transform& other) = 0;
 };
 
+struct ClippingPath
+{
+    ClippingPath(WindingRule aClipRule, std::shared_ptr<Path> aPath, std::shared_ptr<Transform> aTransform)
+        : clipRule{aClipRule}
+        , path{aPath}
+        , transform{aTransform}
+    {}
+
+    WindingRule clipRule = WindingRule::kNonZero;
+    std::shared_ptr<Path> path; /** Clipping path. **/
+    std::shared_ptr<Transform> transform; /** Joined transformation matrix based to the "transform" attribute. **/
+};
+
 /**
  * All compositing related properties. With the exception of the
  */
@@ -168,7 +181,7 @@ struct GraphicStyle
     // Add blend modes and other graohic style options here.
     float opacity = 1.0; /** Corresponds to the "opacty" CSS property. **/
     std::shared_ptr<Transform> transform; /** Joined transformation matrix based to the "transform" attribute. **/
-    std::shared_ptr<Shape> clippingPath;
+    std::shared_ptr<ClippingPath> clippingPath;
 };
 
 /**
@@ -188,20 +201,6 @@ public:
     virtual void CurveTo(float x1, float y1, float x2, float y2, float x3, float y3) = 0;
     virtual void CurveToV(float x2, float y2, float x3, float y3) = 0;
     virtual void ClosePath() = 0;
-};
-
-/**
- * A shape is the combination of one or more Path objects with winding rules for each path
- * object.
- * Transforms and unions only apply to Shapes.
- */
-class Shape
-{
-public:
-    virtual ~Shape() = default;
-
-    virtual void Transform(const Transform& transform) = 0;
-    virtual void Union(const Shape& shape) = 0;
 };
 
 /**
@@ -229,7 +228,6 @@ public:
 
     virtual std::unique_ptr<ImageData> CreateImageData(const std::string& base64) = 0;
     virtual std::unique_ptr<Path> CreatePath() = 0;
-    virtual std::unique_ptr<Shape> CreateShape(const Path& path, WindingRule windingRule = WindingRule::kNonZero) = 0;
     virtual std::unique_ptr<Transform> CreateTransform(
         float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) = 0;
 

--- a/svgnative/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/ports/cg/CGSVGRenderer.cpp
@@ -89,7 +89,7 @@ void CGSVGRenderer::Save(const GraphicStyle& graphicStyle)
         auto path = static_cast<const CGSVGPath*>(graphicStyle.clippingPath->path.get())->mPath;
         if (graphicStyle.clippingPath->transform)
         {
-            auto newPath = CGPathCreateCopyByTransformingPath(path, static_cast<CGSVGTransform*>(graphicStyle.clippingPath->transform.get())->mTransform);
+            auto newPath = CGPathCreateCopyByTransformingPath(path, &static_cast<CGSVGTransform*>(graphicStyle.clippingPath->transform.get())->mTransform);
             CGContextAddPath(mContext, newPath);
             CGPathRelease(newPath);
         }

--- a/svgnative/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/ports/cg/CGSVGRenderer.cpp
@@ -16,6 +16,8 @@ namespace SVGNative
 {
 CGSVGPath::CGSVGPath() { mPath = CGPathCreateMutable(); }
 
+CGSVGPath::~CGSVGPath() { CGPathRelease(mPath); }
+
 void CGSVGPath::Rect(float x, float y, float width, float height) { CGPathAddRect(mPath, 0, {{x, y}, {width, height}}); }
 
 void CGSVGPath::RoundedRect(float x, float y, float width, float height, float cornerRadius)
@@ -73,12 +75,6 @@ void CGSVGTransform::Concat(const Transform& other)
     mTransform = CGAffineTransformConcat(mTransform, static_cast<const CGSVGTransform&>(other).mTransform);
 }
 
-CGSVGShape::CGSVGShape(const Path&, WindingRule) {}
-
-void CGSVGShape::Transform(const class Transform&) {}
-
-void CGSVGShape::Union(const Shape&) {}
-
 CGSVGRenderer::CGSVGRenderer() {}
 
 void CGSVGRenderer::Save(const GraphicStyle& graphicStyle)
@@ -87,6 +83,23 @@ void CGSVGRenderer::Save(const GraphicStyle& graphicStyle)
     CGContextSaveGState(mContext);
     if (graphicStyle.transform)
         CGContextConcatCTM(mContext, static_cast<CGSVGTransform*>(graphicStyle.transform.get())->mTransform);
+    if (graphicStyle.clippingPath)
+    {
+        CGContextBeginPath(mContext);
+        auto path = static_cast<const CGSVGPath*>(graphicStyle.clippingPath->path.get())->mPath;
+        if (graphicStyle.clippingPath->transform)
+        {
+            auto newPath = CGPathCreateCopyByTransformingPath(path, static_cast<CGSVGTransform*>(graphicStyle.clippingPath->transform.get())->mTransform);
+            CGContextAddPath(mContext, newPath);
+            CGPathRelease(newPath);
+        }
+        else
+            CGContextAddPath(mContext, path);   
+        if (graphicStyle.clippingPath->clipRule == WindingRule::kEvenOdd)
+            CGContextEOClip(mContext);
+        else
+            CGContextClip(mContext);
+    }
     CGContextSetAlpha(mContext, graphicStyle.opacity);
     CGContextBeginTransparencyLayer(mContext, 0);
 }

--- a/svgnative/ports/cg/CGSVGRenderer.h
+++ b/svgnative/ports/cg/CGSVGRenderer.h
@@ -23,6 +23,7 @@ class CGSVGPath final : public Path
 {
 public:
     CGSVGPath();
+    ~CGSVGPath();
 
     void Rect(float x, float y, float width, float height) override;
     void RoundedRect(float x, float y, float width, float height, float cornerRadius) override;
@@ -53,16 +54,6 @@ public:
     void Concat(const Transform& other) override;
 
     CGAffineTransform mTransform;
-};
-
-class CGSVGShape final : public Shape
-{
-public:
-    CGSVGShape(const Path& path, WindingRule windingRule);
-
-    void Transform(const class Transform& transform) override;
-
-    void Union(const Shape& other) override;
 };
 
 class CGSVGImageData final : public ImageData
@@ -108,11 +99,6 @@ public:
     std::unique_ptr<ImageData> CreateImageData(const std::string& base64) override { return std::make_unique<CGSVGImageData>(base64); }
 
     std::unique_ptr<Path> CreatePath() override { return std::make_unique<CGSVGPath>(); }
-
-    std::unique_ptr<Shape> CreateShape(const Path& path, WindingRule windingRule) override
-    {
-        return std::make_unique<CGSVGShape>(path, windingRule);
-    }
 
     std::unique_ptr<Transform> CreateTransform(
         float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) override

--- a/svgnative/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/ports/skia/SkiaSVGRenderer.cpp
@@ -92,7 +92,7 @@ void SkiaSVGRenderer::Save(const GraphicStyle& graphicStyle)
             const auto& matrix = static_cast<const SkiaSVGTransform*>(graphicStyle.clippingPath->transform.get())->mMatrix;
             clippingPath.transform(matrix);
         }
-        clippingPath.setFillType(graphicStyle.clippingPath->clipRule == WindingRule::kNonZero ? kWinding_FillType : kEvenOdd_FillType);
+		clippingPath.setFillType(graphicStyle.clippingPath->clipRule == WindingRule::kNonZero ? SkPath::kWinding_FillType : SkPath::kEvenOdd_FillType);
         mCanvas->clipPath(clippingPath);
     }
 }

--- a/svgnative/ports/skia/SkiaSVGRenderer.h
+++ b/svgnative/ports/skia/SkiaSVGRenderer.h
@@ -57,16 +57,6 @@ public:
     SkMatrix mMatrix;
 };
 
-class SkiaSVGShape final : public Shape
-{
-public:
-    SkiaSVGShape(const Path& path, WindingRule windingRule);
-
-    void Transform(const class Transform& transform) override;
-
-    void Union(const Shape& other) override;
-};
-
 class SkiaSVGImageData final : public ImageData
 {
 public:
@@ -85,11 +75,6 @@ public:
     std::unique_ptr<ImageData> CreateImageData(const std::string& base64) override { return std::make_unique<SkiaSVGImageData>(base64); }
 
     std::unique_ptr<Path> CreatePath() override { return std::make_unique<SkiaSVGPath>(); }
-
-    std::unique_ptr<Shape> CreateShape(const Path& path, WindingRule windingRule) override
-    {
-        return std::make_unique<SkiaSVGShape>(path, windingRule);
-    }
 
     std::unique_ptr<Transform> CreateTransform(
         float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) override

--- a/svgnative/ports/string/StringSVGRenderer.cpp
+++ b/svgnative/ports/string/StringSVGRenderer.cpp
@@ -106,12 +106,6 @@ void StringSVGTransform::Multiply(const AffineTransform& o)
     mTransform = newT;
 }
 
-StringSVGShape::StringSVGShape(const Path&, WindingRule) {}
-
-void StringSVGShape::Transform(const class Transform&) {}
-
-void StringSVGShape::Union(const Shape&) {}
-
 StringSVGRenderer::StringSVGRenderer() { mStringStream.precision(3); }
 
 void StringSVGRenderer::Save(const GraphicStyle& graphicStyle)
@@ -227,24 +221,14 @@ void StringSVGRenderer::WriteGraphic(const GraphicStyle& graphicStyle)
         mStringStream << " opacity: " << graphicStyle.opacity;
     if (graphicStyle.transform)
         mStringStream << " transform: " << static_cast<StringSVGTransform*>(graphicStyle.transform.get())->String();
-    if (graphicStyle.clippingPath)
+    if (graphicStyle.clippingPath && graphicStyle.clippingPath->path)
     {
         mStringStream << " clipping: {";
-        // WriteNewline();
-        // IncIndent();
-
-        //        auto clipping = graphicStyle.clippingPath.get();
-
-        // auto shape
-        // WriteNewline();
-        // WriteIndent();
-        // mStringStream << "(clipPath) " << .String();
-
-        mStringStream << "}";
-
-        // DecIndent();
-        // WriteNewline();
-        // WriteIndent();
+        mStringStream << " winding: " << (graphicStyle.clippingPath->clipRule == WindingRule::kNonZero ? "nonzero" : "evenodd");
+        if (graphicStyle.clippingPath->transform)
+            mStringStream << " transform: " << static_cast<StringSVGTransform*>(graphicStyle.clippingPath->transform.get())->String();
+        mStringStream <<  "[path" << static_cast<const StringSVGPath*>(graphicStyle.clippingPath->path.get())->String();
+        mStringStream << "]}";
     }
 }
 

--- a/svgnative/ports/string/StringSVGRenderer.cpp
+++ b/svgnative/ports/string/StringSVGRenderer.cpp
@@ -227,7 +227,7 @@ void StringSVGRenderer::WriteGraphic(const GraphicStyle& graphicStyle)
         mStringStream << " winding: " << (graphicStyle.clippingPath->clipRule == WindingRule::kNonZero ? "nonzero" : "evenodd");
         if (graphicStyle.clippingPath->transform)
             mStringStream << " transform: " << static_cast<StringSVGTransform*>(graphicStyle.clippingPath->transform.get())->String();
-        mStringStream <<  "[path" << static_cast<const StringSVGPath*>(graphicStyle.clippingPath->path.get())->String();
+        mStringStream <<  " [path" << static_cast<const StringSVGPath*>(graphicStyle.clippingPath->path.get())->String();
         mStringStream << "]}";
     }
 }

--- a/svgnative/ports/string/StringSVGRenderer.h
+++ b/svgnative/ports/string/StringSVGRenderer.h
@@ -72,16 +72,6 @@ private:
     AffineTransform mTransform{};
 };
 
-class StringSVGShape final : public Shape
-{
-public:
-    StringSVGShape(const Path& path, WindingRule windingRule);
-
-    void Transform(const class Transform& transform) override;
-
-    void Union(const Shape& other) override;
-};
-
 class StringSVGImageData final : public ImageData
 {
 public:
@@ -109,11 +99,6 @@ public:
     std::unique_ptr<ImageData> CreateImageData(const std::string& base64) override { return std::make_unique<StringSVGImageData>(base64); }
 
     std::unique_ptr<Path> CreatePath() override { return std::make_unique<StringSVGPath>(); }
-
-    std::unique_ptr<Shape> CreateShape(const Path& path, WindingRule windingRule) override
-    {
-        return std::make_unique<StringSVGShape>(path, windingRule);
-    }
 
     std::unique_ptr<Transform> CreateTransform(
         float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) override

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -151,33 +151,6 @@ float SVGDocumentImpl::ParseLengthFromAttr(XMLNode* node, const char* attrName, 
     return number;
 }
 
-WindingRule SVGDocumentImpl::ParseClipRule(XMLNode* node)
-{
-    auto clipRule = WindingRule::kNonZero;
-    auto attr = node->first_attribute("clip-rule");
-    if (attr && std::string(attr->value()) == "evenodd")
-        clipRule = WindingRule::kEvenOdd;
-
-    attr = node->first_attribute("style");
-    if (attr)
-    {
-        auto doc = StyleSheet::CssDocument::parse(attr->value());
-        auto element = doc.getElements().front();
-        auto propertySet = element.getProperties();
-
-        auto prop = propertySet.getProperty("clip-rule");
-        if (prop.isValid())
-        {
-            if (std::string(prop.getValue().c_str()) == "evenodd")
-                clipRule = WindingRule::kEvenOdd;
-            else if (std::string(prop.getValue().c_str()) == "nonzero")
-                clipRule = WindingRule::kNonZero;
-        }
-    }
-
-    return clipRule;
-}
-
 void SVGDocumentImpl::ParseChildren(XMLNode* node)
 {
     for (auto child = node->first_node(); child != nullptr; child = child->next_sibling())
@@ -422,31 +395,34 @@ void SVGDocumentImpl::ParseResource(XMLNode* child)
         if (!id)
             return;
 
+        mFillStyleStack.push(fillStyle);
+        mStrokeStyleStack.push(strokeStyle);
+
         // SVG only allows shapes (and <use> elements referencing shapes) as children of
         // <clipPath>. Ignore all other elements.
-        std::shared_ptr<Shape> clipShape;
         for (auto clipPathChild = child->first_node(); clipPathChild != nullptr; clipPathChild = clipPathChild->next_sibling())
         {
             if (auto path = ParseShape(clipPathChild))
             {
-                auto siblingShape = mRenderer->CreateShape(*path, ParseClipRule(child));
+                std::unique_ptr<Transform> transform;
                 if (auto transformAttr = clipPathChild->first_attribute("transform"))
                 {
                     auto transformHandler = [&]() {
                         SVG_ASSERT(mRenderer != nullptr);
                         return mRenderer->CreateTransform();
                     };
-                    if (auto transform = SVGStringParser::ParseTransform(transformAttr->value(), transformHandler))
-                        siblingShape->Transform(*transform);
+                    transform = SVGStringParser::ParseTransform(transformAttr->value(), transformHandler);
                 }
-                if (!clipShape)
-                    clipShape = std::move(siblingShape);
-                else
-                    clipShape->Union(*siblingShape);
+                auto fillStyleChild = mFillStyleStack.top();
+                auto strokeStyleChild = mStrokeStyleStack.top();
+                std::set<std::string> classNames;
+                ParseGraphic(child, fillStyleChild, strokeStyleChild, classNames);
+                mClippingPaths[id->value()] = std::make_shared<ClippingPath>(fillStyleChild.clipRule, std::move(path), std::move(transform));
+                break;
             }
         }
-        if (clipShape)
-            mClippingPaths[id->value()] = std::move(clipShape);
+        mFillStyleStack.pop();
+        mStrokeStyleStack.pop();
     }
     else
     {

--- a/svgnative/src/SVGDocumentImpl.h
+++ b/svgnative/src/SVGDocumentImpl.h
@@ -193,8 +193,6 @@ private:
 
     StyleSheet::CssPropertySet ParsePresentationAttributes(XMLNode* node);
 
-    WindingRule ParseClipRule(XMLNode* node);
-
     void ParseStyle(XMLNode* child);
 
     void TraverseTree(const ColorMap& colorMap, const Element*);
@@ -219,7 +217,7 @@ private:
 
     std::map<std::string, GradientImpl> mGradients;
     std::map<std::string, XMLNode*> mResourceIDs;
-    std::map<std::string, std::shared_ptr<Shape>> mClippingPaths;
+    std::map<std::string, std::shared_ptr<ClippingPath>> mClippingPaths;
 
     std::stack<Group*> mGroupStack;
     std::unique_ptr<Group> mGroup;

--- a/svgnative/test/clipping.svg
+++ b/svgnative/test/clipping.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="200" height="250" viewBox="0 0 200 250">
+    <defs>
+        <!-- ClipPath w/o content -->
+        <clipPath id="c1">
+        </clipPath>
+        <!-- ClipPath w/ different shapes -->
+        <clipPath id="c2">
+            <circle cx="60" cy="20" r="20"/>
+        </clipPath>
+        <clipPath id="c3">
+            <ellipse cx="100" cy="20" rx="20" ry="15"/>
+        </clipPath>
+        <clipPath id="c4">
+            <rect x="130" y="10" width="20" height="20" rx="5" ry="5"/>
+        </clipPath>
+        <clipPath id="c5">
+            <path d="M180 10 L190 35 L170 35"/>
+        </clipPath>
+        <clipPath id="c6">
+            <polyline points="20,50 30,75 10,75"/>
+        </clipPath>
+        <clipPath id="c7">
+            <circle cx="20" cy="20" r="20" transform="translate(40, 40)"/>
+        </clipPath>
+        <!-- Invalid content -->
+        <clipPath id="c8">
+            <g>
+                <circle cx="100" cy="60" r="20"/>
+            </g>
+        </clipPath>
+        <clipPath id="c9">
+            <circle cx="140" cy="60" r="20"/>
+            <g>
+                <rect x="-200" y="-200" width="200" height="200"/>
+            </g>
+        </clipPath>
+        <clipPath id="c10">
+            <g>
+                <rect x="-200" y="-200" width="200" height="200"/>
+            </g>
+            <circle cx="180" cy="60" r="20"/>
+        </clipPath>
+        <clipPath id="c11">
+            <circle cx="20" cy="100" r="20"/>
+            <rect x="-200" y="-200" width="200" height="200"/>
+        </clipPath>
+        <!-- clip related properties and attributes -->
+        <clipPath id="c12">
+            <circle cx="60" cy="100" r="20" clip-rule="evenodd"/>
+        </clipPath>
+        <clipPath id="c13" clip-rule="evenodd">
+            <circle cx="100" cy="100" r="20"/>
+        </clipPath>
+    </defs>
+    <defs clip-rule="evenodd">
+        <clipPath id="c14">
+            <circle cx="140" cy="100" r="20"/>
+        </clipPath>
+    </defs>
+    <defs>
+        <clipPath id="c15">
+            <circle cx="180" cy="100" r="20"/>
+        </clipPath>
+        <!-- clipping paths operate in the coordinate space of the referencing element -->
+        <clipPath id="c16">
+            <circle cx="20" cy="20" r="20"/>
+        </clipPath>
+    </defs>
+    <rect width="40" height="40" x="0" y="0" clip-path="url(#c1)"/>
+    <rect width="40" height="40" x="40" y="0" clip-path="url(#c2)"/>
+    <rect width="40" height="40" x="80" y="0" clip-path="url(#c3)"/>
+    <rect width="40" height="40" x="120" y="0" clip-path="url(#c4)"/>
+    <rect width="40" height="40" x="160" y="0" clip-path="url(#c5)"/>
+    <rect width="40" height="40" x="0" y="40" clip-path="url(#c6)"/>
+    <rect width="40" height="40" x="40" y="40" clip-path="url(#c7)"/>
+    <rect width="40" height="40" x="80" y="40" clip-path="url(#c8)"/>
+    <rect width="40" height="40" x="120" y="40" clip-path="url(#c9)"/>
+    <rect width="40" height="40" x="160" y="40" clip-path="url(#c10)"/>
+    <rect width="40" height="40" x="0" y="80" clip-path="url(#c11)"/>
+    <rect width="40" height="40" x="40" y="80" clip-path="url(#c12)"/>
+    <rect width="40" height="40" x="80" y="80" clip-path="url(#c13)"/>
+    <rect width="40" height="40" x="120" y="80" clip-path="url(#c14)"/>
+    <rect width="40" height="40" x="160" y="80" clip-path="url(#c15)" clip-rule="evenodd"/>
+    <rect width="40" height="40" x="0" y="0" clip-path="url(#c16)" transform="translate(0, 120)"/>
+</svg>

--- a/svgnative/test/clipping.txt
+++ b/svgnative/test/clipping.txt
@@ -1,0 +1,46 @@
+[group transform: matrix(1,0,0,1,0,0)
+    [group
+        [path Rect(40,0,40,40) clipping: { winding: nonzero [path Ellipse(60,20,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(80,0,40,40) clipping: { winding: nonzero [path Ellipse(100,20,20,15)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(120,0,40,40) clipping: { winding: nonzero [path RoundedRect(130,10,20,20,5)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(160,0,40,40) clipping: { winding: nonzero [path M180,10 L190,35 L170,35]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,40,40,40) clipping: { winding: nonzero [path M20,50 L30,75 L10,75]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(40,40,40,40) clipping: { winding: nonzero transform: matrix(1,0,0,1,40,40) [path Ellipse(20,20,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(120,40,40,40) clipping: { winding: nonzero [path Ellipse(140,60,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(160,40,40,40) clipping: { winding: nonzero [path Ellipse(180,60,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,80,40,40) clipping: { winding: nonzero [path Ellipse(20,100,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(40,80,40,40) clipping: { winding: nonzero [path Ellipse(60,100,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(80,80,40,40) clipping: { winding: evenodd [path Ellipse(100,100,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(120,80,40,40) clipping: { winding: evenodd [path Ellipse(140,100,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(160,80,40,40) clipping: { winding: nonzero [path Ellipse(180,100,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,0,40,40) transform: matrix(1,0,0,1,0,120) clipping: { winding: nonzero [path Ellipse(20,20,20,20)]}
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+    ]
+]


### PR DESCRIPTION
The implementation is based on the latest specification draft of SVG Native. Only one clipping shape is supported. Therefore, we don't need to create the union of paths.