### PR TITLE
change protocol to access 3rd party repos, from ssh to https.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/stylesheet"]
 	path = third_party/stylesheet
-	url = git@github.com:adobe/stylesheet.git
+	url = https://github.com/adobe/stylesheet.git
 	branch = modifications
 [submodule "third_party/cpp-base64"]
 	path = third_party/cpp-base64
-	url = git@github.com:ReneNyffenegger/cpp-base64.git
+	url = https://github.com/ReneNyffenegger/cpp-base64.git


### PR DESCRIPTION
currently, .gitmodule sets the protocol for 3rd party repos to ssh, like, "url = git@github.com:adobe/stylesheet.git". I suggest to change it to https, like, "url = https://github.com/adobe/stylesheet.git". It could be slightly more convenient to download & compile on the systems without registered ssh keys.