### PR TITLE
bugfix: encoding = ImageEncoding::kJPEG, if dataURL declares its content as jpg or jpeg.

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -201,12 +201,12 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
             }
             else if (dataURL.find("data:image/jpg;base64,") == 0)
             {
-                encoding = ImageEncoding::kPNG;
+                encoding = ImageEncoding::kJPEG;
                 base64Offset = 22;
             }
             else if (dataURL.find("data:image/jpeg;base64,") == 0)
             {
-                encoding = ImageEncoding::kPNG;
+                encoding = ImageEncoding::kJPEG;
                 base64Offset = 23;
             }
             else


### PR DESCRIPTION
Maybe mistakenly it has been set to ImageEncoding::kPNG.