### PR TITLE
Prevent a crash caused by empty css element list.

### DIFF
--- a/svgnative/src/DeprecatedSVGDocumentImpl.cpp
+++ b/svgnative/src/DeprecatedSVGDocumentImpl.cpp
@@ -110,8 +110,11 @@ void SVGDocumentImpl::ParseStyleAttr(XMLNode* node, std::vector<PropertySet>& pr
     if (attr)
     {
         auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
-        auto cssElement = cssDoc.getElements().front();
-        propertySets.push_back(cssElement.getProperties());
+        auto cssElements = cssDoc.getElements();
+        if (!cssElements.empty())
+        {
+            propertySets.push_back(cssElements.front().getProperties());
+        }
     }
     // Warning: The inheritance order is incorrect but required by current clients at this point.
     // The code is going to get removed once clients do no longer use "<style>" or

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -570,9 +570,15 @@ GraphicStyleImpl SVGDocumentImpl::ParseGraphic(
     auto attr = node->first_attribute("style");
     if (attr)
     {
-        auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
-        auto cssElement = cssDoc.getElements().front();
-        propertySets.push_back(cssElement.getProperties());
+        try
+        {
+            auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
+            auto cssElement = cssDoc.getElements().front();
+            propertySets.push_back(cssElement.getProperties());
+        }
+        catch (...) 
+        {
+        }
     }
     // Warning: The inheritance order is incorrect but required by current clients at this point.
     // The code is going to get removed once clients do no longer use "<style>" or

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -570,15 +570,9 @@ GraphicStyleImpl SVGDocumentImpl::ParseGraphic(
     auto attr = node->first_attribute("style");
     if (attr)
     {
-        try
-        {
-            auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
-            auto cssElement = cssDoc.getElements().front();
-            propertySets.push_back(cssElement.getProperties());
-        }
-        catch (...) 
-        {
-        }
+        auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
+        auto cssElement = cssDoc.getElements().front();
+        propertySets.push_back(cssElement.getProperties());
     }
     // Warning: The inheritance order is incorrect but required by current clients at this point.
     // The code is going to get removed once clients do no longer use "<style>" or


### PR DESCRIPTION
Giving this file https://www.w3.org/TR/SVG11/images/paths/cubic01.svg to the example "testSVGNative" for the text backend, I got a crash like this.

(gdb) run moretest/cubic01.svg cubic01.txt
Starting program: /home/sssa/redhat/BUILD/svg-native-viewer/svgnative/Build/linux-20190516/example/testText/testSVGNative moretest/cubic01.svg cubic01.txt

Program received signal SIGSEGV, Segmentation fault.
0x00005555555605cc in std::__uniq_ptr_impl<SVGNative::SVGDocumentImpl, std::default_delete<SVGNative::SVGDocumentImpl> >::_M_ptr (this=0x0) at /usr/include/c++/7/bits/unique_ptr.h:147
147           pointer    _M_ptr() const { return std::get<0>(_M_t); }
(gdb) where
#0  0x00005555555605cc in std::__uniq_ptr_impl<SVGNative::SVGDocumentImpl, std::default_delete<SVGNative::SVGDocumentImpl> >::_M_ptr (this=0x0) at /usr/include/c++/7/bits/unique_ptr.h:147
#1  0x000055555555f55a in std::unique_ptr<SVGNative::SVGDocumentImpl, std::default_delete<SVGNative::SVGDocumentImpl> >::get
    (this=0x0) at /usr/include/c++/7/bits/unique_ptr.h:337
#2  0x000055555555e5d2 in std::unique_ptr<SVGNative::SVGDocumentImpl, std::default_delete<SVGNative::SVGDocumentImpl> >::operator-> (this=0x0) at /usr/include/c++/7/bits/unique_ptr.h:331
#3  0x000055555555d7af in SVGNative::SVGDocument::Render (this=0x0, colorMap=std::map with 3 elements = {...})
    at /home/sssa/redhat/BUILD/svg-native-viewer/svgnative/src/SVGDocument.cpp:67
#4  0x000055555555a876 in main (argc=3, argv=0x7fffffffdec8)
    at /home/sssa/redhat/BUILD/svg-native-viewer/svgnative/example/testText/TestMain.cpp:53

--

This call stack is hard to identify the problem, but during step-by-step execution, I found something like this.

the original code was looking like this.

if (attr)
{
        auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
        auto cssElement = cssDoc.getElements().front();
        propertySets.push_back(cssElement.getProperties());
}

I got a crash at "cssElement = cssDoc.getElements().front()". I divided it to 2 lines, like,

if (attr)
{
        auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
        auto cssElements = cssDoc.getElements();
        auto cssElement = cssElements.front();
        propertySets.push_back(cssElement.getProperties());
}

and I found such crash.

(gdb) run moretest/cubic01.svg cubic01.txt
Starting program: /home/sssa/redhat/BUILD/svg-native-viewer/svgnative/Build/linux-20190516/example/testText/testSVGNative moretest/cubic01.svg cubic01.txt

Breakpoint 1, SVGNative::SVGDocumentImpl::ParseGraphic (this=0x5555557fc680, node=0x5555557fe158, fillStyle=...,
    strokeStyle=..., classNames=std::set with 0 elements)
    at /home/sssa/redhat/BUILD/svg-native-viewer/svgnative/src/SVGDocumentImpl.cpp:573
573             auto cssDoc = StyleSheet::CssDocument::parse(attr->value());
(gdb) n
574             auto cssElements = cssDoc.getElements();
(gdb)
575             auto cssElement = cssElements.front();
(gdb)

Program received signal SIGSEGV, Segmentation fault.
0x00005555555605cc in std::__uniq_ptr_impl<SVGNative::SVGDocumentImpl, std::default_delete<SVGNative::SVGDocumentImpl> >::_M_ptr (this=0x0) at /usr/include/c++/7/bits/unique_ptr.h:147
147           pointer    _M_ptr() const { return std::get<0>(_M_t); }

So I think if cssElements() is an empty list, front() causes some errors. My patch enclose this part in try and catch() to prevent the crash.
