### PR TITLE
add stroke-width feature to Skia backend

### DIFF
--- a/svgnative/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/ports/skia/SkiaSVGRenderer.cpp
@@ -200,6 +200,7 @@ void SkiaSVGRenderer::DrawPath(
     {
         SkPaint stroke;
         stroke.setStyle(SkPaint::kStroke_Style);
+        stroke.setStrokeWidth(strokeStyle.lineWidth);
         CreateSkPaint(strokeStyle.paint, strokeStyle.strokeOpacity, stroke);
         mCanvas->drawPath(static_cast<const SkiaSVGPath&>(path).mPath, stroke);
     }


### PR DESCRIPTION
The addition of stroke-width feature might be far simpler than that of dashed-array, I apologize that I have not requested this before. It's just because of my laziness to read the API reference of Skia.