### PR TITLE
Take into account viewbox translations too.

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -964,6 +964,7 @@ void SVGDocumentImpl::Render(const ColorMap& colorMap, float width, float height
 
     GraphicStyleImpl graphicStyle{};
     graphicStyle.transform = mRenderer->CreateTransform();
+    graphicStyle.transform->Translate(-1 * mViewBox[0], -1 * mViewBox[1]);
     graphicStyle.transform->Scale(scale, scale);
 
     mRenderer->Save(graphicStyle);


### PR DESCRIPTION
At the moment, the library doesn't take care of any viewbox shifting as @mpsuzuki illustrates in #33. This is one way to fix that which works for me, though I am not sure whether it's the right way. 