### PR TITLE
Fix the support for `use' elements.

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -339,9 +339,9 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
         mGroupStack.push(tempGroupPtr);
 
         if(resourceIt->second->first_node() == 0)
-          ParseChild(resourceIt->second);
+            ParseChild(resourceIt->second);
         else
-          ParseChildren(resourceIt->second);
+            ParseChildren(resourceIt->second);
 
         mGroupStack.pop();
         mFillStyleStack.pop();


### PR DESCRIPTION
This is an attempt to fix #35. The changes from line 320-323 are really crude. However, I am not too familiar with how `xlink:href` is supposed to behave. 