### PR TITLE
Support gradient elements outside `defs`.

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -370,8 +370,11 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
 
         mGroupStack.pop();
     }
-    else if (elementName == "style")
-        ParseStyle(child);
+    else if (elementName == "style" ||
+             elementName == "linearGradient" ||
+             elementName == "radialGradient" ||
+             elementName == "clipPath")
+        ParseResource(child);
 }
 
 void SVGDocumentImpl::ParseResources(XMLNode* node)

--- a/svgnative/test/gradient-outside-defs.svg
+++ b/svgnative/test/gradient-outside-defs.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150" height="250" viewBox="0 0 150 250">
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse">
+        <stop stop-color="#0000FF" offset="0"/>
+        <stop stop-color="#00FF00" offset="1"/>
+    </linearGradient>
+    <radialGradient id="g2" gradientUnits="userSpaceOnUse">
+        <stop stop-color="#0000FF" offset="0"/>
+        <stop stop-color="#00FF00" offset="1"/>
+    </radialGradient>
+    <rect width="150" height="10" fill="url(#g1)" y="180"/>
+    <rect width="150" height="10" fill="url(#g2)" y="180"/>
+</svg>

--- a/svgnative/test/gradient-outside-defs.txt
+++ b/svgnative/test/gradient-outside-defs.txt
@@ -1,0 +1,18 @@
+[group transform: matrix(1,0,0,1,0,0)
+    [group
+        [path Rect(0,180,150,10)
+            fill: {hasFill: true winding: nonzero paint: {
+                linearGradient: x1: 0 y1: 0 x2: 150 y2: 0 method: pad stops: {
+                    offset: 0 rgba(0,0,1,1)
+                    offset: 1 rgba(0,1,0,1)
+                }}}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,180,150,10)
+            fill: {hasFill: true winding: nonzero paint: {
+                radialGradient: cx: 75 cy: 125 fx: 75 fy: 125 method: pad stops: {
+                    offset: 0 rgba(0,0,1,1)
+                    offset: 1 rgba(0,1,0,1)
+                }}}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+    ]
+]


### PR DESCRIPTION
I am not sure if this would be the best way to fix it. Instead of creating multiple `else if` statements in `ParseChild` and copy-pasting sections of code from `ParseResource`, it's probably better to write one `else if` in `ParseChild` and let `ParseResource` do the actual job. 

This should close #36. 