### PR TITLE
Add a support for dashed line to Skia backend.

### DIFF
--- a/svgnative/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/ports/skia/SkiaSVGRenderer.cpp
@@ -21,6 +21,7 @@ governing permissions and limitations under the License.
 #include "SkRect.h"
 #include "SkRRect.h"
 #include "SkShader.h"
+#include "SkDashPathEffect.h"
 #include <math.h>
 
 namespace SVGNative
@@ -201,6 +202,12 @@ void SkiaSVGRenderer::DrawPath(
         SkPaint stroke;
         stroke.setStyle(SkPaint::kStroke_Style);
         stroke.setStrokeWidth(strokeStyle.lineWidth);
+        if (!strokeStyle.dashArray.empty())
+        {
+            stroke.setPathEffect(SkDashPathEffect::Make((SkScalar*)(strokeStyle.dashArray.data()),
+                                                        strokeStyle.dashArray.size(),
+                                                        (SkScalar)strokeStyle.dashOffset));
+        }
         CreateSkPaint(strokeStyle.paint, strokeStyle.strokeOpacity, stroke);
         mCanvas->drawPath(static_cast<const SkiaSVGPath&>(path).mPath, stroke);
     }

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -762,6 +762,15 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
                 break;
             }
         }
+        auto sizeOfDashArray = strokeStyle.dashArray.size();
+        if (sizeOfDashArray % 2 != 0)
+        {
+            // If stroke-dasharray[] is odd-sized, the array should be twiced.
+            // See SVG 1.1 (2nd ed), 11.4 "Stroke Properties" for detail.
+            strokeStyle.dashArray.reserve(sizeOfDashArray * 2);
+            for (size_t i = 0; i < sizeOfDashArray; ++i)
+                strokeStyle.dashArray.push_back( strokeStyle.dashArray[i] );
+        }
     }
 
     prop = propertySet.find("stroke-opacity");

--- a/svgnative/test/dash-array.txt
+++ b/svgnative/test/dash-array.txt
@@ -2,25 +2,25 @@
     [group
         [path M0,5 L200,5
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
-            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 dashOffset: 0 paint: rgba(0,0,0,1)}]
+            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 20 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,10 L200,10
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
             stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 10 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,15 L200,15
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
-            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 0 0 0 10 dashOffset: 0 paint: rgba(0,0,0,1)}]
+            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 0 0 0 10 20 0 0 0 10 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,20 L200,20
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
             stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 0.99 0.99 0.99 0.99 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,25 L200,25
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
-            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 5 1.33 8 dashOffset: 0 paint: rgba(0,0,0,1)}]
+            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 5 1.33 8 5 1.33 8 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,30 L200,30
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
             stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 7.56 7.56 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,35 L200,35
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
-            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 9.9 20 10 0.9 0.9 dashOffset: 0 paint: rgba(0,0,0,1)}]
+            stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 9.9 20 10 0.9 0.9 9.9 20 10 0.9 0.9 dashOffset: 0 paint: rgba(0,0,0,1)}]
         [path M0,40 L200,40
             fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
             stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 14.1 28.3 dashOffset: 0 paint: rgba(0,0,0,1)}]


### PR DESCRIPTION
* odd-sized dash array is doubled for all backends.

* svgnative/test/dash-array.txt is updated for oddsized cases.