### PR TITLE
Fix some spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Submodules are located in the `third_party/` directory. Used submodules:
 Install:
 * [CMake](https://cmake.org) Download and run the installer
 * [Boost](https://www.boost.org) Download the ZIP-package and extract the package into `C:>\Platform Files\boost\`
-* [MS Visual Studio 2017 or up](https://visualstudio.microsoft.com/vs/whatsnew/) Download and install with the installer. Make sure Visual C++ gets installed. (You maybe be able to use the "Community" version for free for non-comercial/enterprise use. See the website from MS for license details.)
+* [MS Visual Studio 2017 or up](https://visualstudio.microsoft.com/vs/whatsnew/) Download and install with the installer. Make sure Visual C++ gets installed. (You maybe be able to use the "Community" version for free for non-commercial/enterprise use. See the website from MS for license details.)
 ### OSX
 With Homebrew:
 ```

--- a/svgnative/include/SVGDocument.h
+++ b/svgnative/include/SVGDocument.h
@@ -94,7 +94,7 @@ public:
      * color variables.
      * The viewport of the SVG document will be scaled uniformly to fit into the area
      * defined by the width and height arguments.
-     * @param width Horrizontal dimension of surface.
+     * @param width Horizontal dimension of surface.
      * @param height Vertical dimension of surface.
      */
     void Render(float width, float height);
@@ -118,7 +118,7 @@ public:
      * //     <rect width="200" height="200" fill="var(--myCustomFillColor, #F00)"/>
      * //     <rect width="200" height="200" stroke="var(--myCustomStrokeColor, #0F0)"/>
      * // </svg>
-     * // Note: var() consists of a custom name and, optionally, a comma separaetd fallback CSS color.
+     * // Note: var() consists of a custom name and, optionally, a comma separated fallback CSS color.
      * @encode
      */
     void Render(const ColorMap& colorMap);
@@ -131,7 +131,7 @@ public:
      * defined by the width and height arguments.
      * @param colorMap A string-to-Color map for pre-defined colors that replace
      *      CSS custom properties in the SVG file.
-     * @param width Horrizontal dimension of surface.
+     * @param width Horizontal dimension of surface.
      * @param height Vertical dimension of surface.
      *
      * @code
@@ -146,7 +146,7 @@ public:
      * //     <rect width="200" height="200" fill="var(--myCustomFillColor, #F00)"/>
      * //     <rect width="200" height="200" stroke="var(--myCustomStrokeColor, #0F0)"/>
      * // </svg>
-     * // Note: var() consists of a custom name and, optionally, a comma separaetd fallback CSS color.
+     * // Note: var() consists of a custom name and, optionally, a comma separated fallback CSS color.
      * @encode
      */
     void Render(const ColorMap& colorMap, float width, float height);

--- a/svgnative/include/SVGRenderer.h
+++ b/svgnative/include/SVGRenderer.h
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 namespace SVGNative
 {
 /**
- * Supported image encoding foramts are PNG and JPEG.
+ * Supported image encoding formats are PNG and JPEG.
  * The assumed encoding format based on the base64 string.
  */
 enum class ImageEncoding
@@ -200,8 +200,8 @@ struct ClippingPath
  */
 struct GraphicStyle
 {
-    // Add blend modes and other graohic style options here.
-    float opacity = 1.0; /** Corresponds to the "opacty" CSS property. **/
+    // Add blend modes and other graphic style options here.
+    float opacity = 1.0; /** Corresponds to the "opacity" CSS property. **/
     std::shared_ptr<Transform> transform; /** Joined transformation matrix based to the "transform" attribute. **/
     std::shared_ptr<ClippingPath> clippingPath;
 };

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -66,11 +66,11 @@ void SVGDocumentImpl::TraverseSVGTree()
     if (!HasAttr(rootNode, "viewBox"))
     {
         if (HasAttr(rootNode, "x"))
-            mViewBox[0] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "x", LengthType::kHorrizontal);
+            mViewBox[0] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "x", LengthType::kHorizontal);
         if (HasAttr(rootNode, "y"))
             mViewBox[1] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "y", LengthType::kVertical);
         if (HasAttr(rootNode, "width"))
-            mViewBox[2] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "width", LengthType::kHorrizontal);
+            mViewBox[2] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "width", LengthType::kHorizontal);
         if (HasAttr(rootNode, "height"))
             mViewBox[3] = SVGDocumentImpl::ParseLengthFromAttr(rootNode, "height", LengthType::kVertical);
     }
@@ -111,7 +111,7 @@ float SVGDocumentImpl::RelativeLength(LengthType lengthType) const
     float relLength{};
     switch (lengthType)
     {
-    case LengthType::kHorrizontal:
+    case LengthType::kHorizontal:
         relLength = mViewBox[2];
         break;
     case LengthType::kVertical:
@@ -227,9 +227,9 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
             float imageWidth = imageData->Width();
             float imageHeight = imageData->Height();
 
-            Rect clipArea{ParseLengthFromAttr(child, "x", LengthType::kHorrizontal),
+            Rect clipArea{ParseLengthFromAttr(child, "x", LengthType::kHorizontal),
                 ParseLengthFromAttr(child, "y", LengthType::kVertical),
-                ParseLengthFromAttr(child, "width", LengthType::kHorrizontal, imageWidth),
+                ParseLengthFromAttr(child, "width", LengthType::kHorizontal, imageWidth),
                 ParseLengthFromAttr(child, "height", LengthType::kVertical, imageHeight)};
 
             std::string align;
@@ -331,7 +331,7 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
         mStrokeStyleStack.push(strokeStyle);
 
         auto transform = mRenderer->CreateTransform(
-            1, 0, 0, 1, ParseLengthFromAttr(child, "x", LengthType::kHorrizontal), ParseLengthFromAttr(child, "y", LengthType::kVertical));
+            1, 0, 0, 1, ParseLengthFromAttr(child, "x", LengthType::kHorizontal), ParseLengthFromAttr(child, "y", LengthType::kVertical));
         if (graphicStyle.transform)
             transform->Concat(*graphicStyle.transform);
         graphicStyle.transform = std::move(transform);
@@ -462,10 +462,10 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
     std::string elementName = child->name();
     if (elementName == "rect")
     {
-        float x = ParseLengthFromAttr(child, "x", LengthType::kHorrizontal);
+        float x = ParseLengthFromAttr(child, "x", LengthType::kHorizontal);
         float y = ParseLengthFromAttr(child, "y", LengthType::kVertical);
 
-        float width = ParseLengthFromAttr(child, "width", LengthType::kHorrizontal);
+        float width = ParseLengthFromAttr(child, "width", LengthType::kHorizontal);
         float height = ParseLengthFromAttr(child, "height", LengthType::kVertical);
 
         bool hasRx = HasAttr(child, "rx");
@@ -475,14 +475,14 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
         float ry{};
         if (hasRx && hasRy)
         {
-            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorrizontal);
+            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorizontal);
             ry = ParseLengthFromAttr(child, "ry", LengthType::kVertical);
         }
         else if (hasRx)
         {
             // the svg spec says that rect elements that specify a rx but not a ry
             // should use the rx value for ry
-            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorrizontal);
+            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorizontal);
             ry = rx;
         }
         else if (hasRy)
@@ -519,7 +519,7 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
 
         if (elementName == "ellipse")
         {
-            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorrizontal);
+            rx = ParseLengthFromAttr(child, "rx", LengthType::kHorizontal);
             ry = ParseLengthFromAttr(child, "ry", LengthType::kVertical);
         }
         else
@@ -528,7 +528,7 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
             ry = rx;
         }
 
-        float cx = ParseLengthFromAttr(child, "cx", LengthType::kHorrizontal);
+        float cx = ParseLengthFromAttr(child, "cx", LengthType::kHorizontal);
         float cy = ParseLengthFromAttr(child, "cy", LengthType::kVertical);
 
         auto path = mRenderer->CreatePath();
@@ -576,8 +576,8 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
     else if (elementName == "line")
     {
         auto path = mRenderer->CreatePath();
-        path->MoveTo(ParseLengthFromAttr(child, "x1", LengthType::kHorrizontal), ParseLengthFromAttr(child, "y1", LengthType::kVertical));
-        path->LineTo(ParseLengthFromAttr(child, "x2", LengthType::kHorrizontal), ParseLengthFromAttr(child, "y2", LengthType::kVertical));
+        path->MoveTo(ParseLengthFromAttr(child, "x1", LengthType::kHorizontal), ParseLengthFromAttr(child, "y1", LengthType::kVertical));
+        path->LineTo(ParseLengthFromAttr(child, "x2", LengthType::kHorizontal), ParseLengthFromAttr(child, "y2", LengthType::kVertical));
 
         return path;
     }
@@ -921,7 +921,7 @@ void SVGDocumentImpl::ParseGradient(XMLNode* node)
         return;
     }
 
-    // TODO: Do we want to support `gradientUnits="objectBoundnigBox"` at all?
+    // TODO: Do we want to support `gradientUnits="objectBoundingBox"` at all?
     // This would require us to get the bounding box of the filled/stroked shape
     // when the gradient gets applied.
 
@@ -929,11 +929,11 @@ void SVGDocumentImpl::ParseGradient(XMLNode* node)
     {
         // https://www.w3.org/TR/SVG11/pservers.html#LinearGradients
         if (HasAttr(node, "x1"))
-            gradient.x1 = ParseLengthFromAttr(node, "x1", LengthType::kHorrizontal);
+            gradient.x1 = ParseLengthFromAttr(node, "x1", LengthType::kHorizontal);
         if (HasAttr(node, "y1"))
             gradient.y1 = ParseLengthFromAttr(node, "y1", LengthType::kVertical);
         if (HasAttr(node, "x2"))
-            gradient.x2 = ParseLengthFromAttr(node, "x2", LengthType::kHorrizontal);
+            gradient.x2 = ParseLengthFromAttr(node, "x2", LengthType::kHorizontal);
         if (HasAttr(node, "y2"))
             gradient.y2 = ParseLengthFromAttr(node, "y2", LengthType::kVertical);
     }
@@ -941,11 +941,11 @@ void SVGDocumentImpl::ParseGradient(XMLNode* node)
     {
         // https://www.w3.org/TR/SVG11/pservers.html#RadialGradients
         if (HasAttr(node, "cx"))
-            gradient.cx = ParseLengthFromAttr(node, "cx", LengthType::kHorrizontal);
+            gradient.cx = ParseLengthFromAttr(node, "cx", LengthType::kHorizontal);
         if (HasAttr(node, "cy"))
             gradient.cy = ParseLengthFromAttr(node, "cy", LengthType::kVertical);
         if (HasAttr(node, "fx"))
-            gradient.fx = ParseLengthFromAttr(node, "fx", LengthType::kHorrizontal);
+            gradient.fx = ParseLengthFromAttr(node, "fx", LengthType::kHorizontal);
         if (HasAttr(node, "fy"))
             gradient.fy = ParseLengthFromAttr(node, "fy", LengthType::kVertical);
         if (HasAttr(node, "r"))
@@ -1109,7 +1109,7 @@ void SVGDocumentImpl::TraverseTree(const ColorMap& colorMap, const Element& elem
         fillStyle = graphic.fillStyle;
         strokeStyle = graphic.strokeStyle;
         ApplyCSSStyle(graphic.classNames, graphicStyle, fillStyle, strokeStyle);
-        // If we habe a CSS var() function we need to replace the placeholder with
+        // If we have a CSS var() function we need to replace the placeholder with
         // an actual color from our externally provided color map here.
         Color color{{0.0f, 0.0f, 0.0f, 1.0f}};
         ResolveColorImpl(colorMap, fillStyle.color, color);

--- a/svgnative/src/SVGDocumentImpl.h
+++ b/svgnative/src/SVGDocumentImpl.h
@@ -163,7 +163,7 @@ public:
 
     enum class LengthType
     {
-        kHorrizontal,
+        kHorizontal,
         kVertical,
         kDiagonal
     };
@@ -181,7 +181,7 @@ public:
 
 private:
     bool HasAttr(XMLNode* node, const char* attrName);
-    float ParseLengthFromAttr(XMLNode* child, const char* attrName, LengthType lengthType = LengthType::kHorrizontal, float fallback = 0);
+    float ParseLengthFromAttr(XMLNode* child, const char* attrName, LengthType lengthType = LengthType::kHorizontal, float fallback = 0);
     float RelativeLength(LengthType lengthType) const;
 
     float ParseColorStop(XMLNode* node, std::vector<SVGNative::ColorStopImpl>& colorStops, float lastOffset);
@@ -217,10 +217,10 @@ private:
 private:
     // All stroke and fill CSS properties are so called
     // inherited CSS properties. Ancestors can define the
-    // stroke properties for desandents. Decendants override
+    // stroke properties for descendants. Descendants override
     // specifies from ancestors.
     // We need to keep the stack of settings in based on DOM
-    // hiearchy.
+    // hierarchy.
     std::stack<StrokeStyleImpl> mStrokeStyleStack;
     std::stack<FillStyleImpl> mFillStyleStack;
 

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -179,7 +179,7 @@ static bool ParseScientificNumber(CharIt& pos, const CharIt& end, float& number)
 static bool ParseCoordinate(CharIt& pos, const CharIt& end, float& coord)
 {
     // FIXME: Remove initial SkipOptWspOrDelimiter call. Keep it here to keep
-    // behavior consitent to previous implementation.
+    // behavior consistent to previous implementation.
     if (!SkipOptWspOrDelimiter(pos, end))
         return false;
     if (!ParseScientificNumber(pos, end, coord))
@@ -190,7 +190,7 @@ static bool ParseCoordinate(CharIt& pos, const CharIt& end, float& coord)
 static bool ParseCoordinatePair(CharIt& pos, const CharIt& end, float& x, float& y)
 {
     // FIXME: Remove initial SkipOptWspOrDelimiter call. Keep it here to keep
-    // behavior consitent to previous implementation.
+    // behavior consistent to previous implementation.
     if (!SkipOptWspOrDelimiter(pos, end))
         return false;
     if (!ParseScientificNumber(pos, end, x))
@@ -1072,7 +1072,7 @@ SVGDocumentImpl::Result ParsePaint(const std::string& colorString, const std::ma
                     paint = std::get<1>(gradient.internalColorStops.front());
                 else
                 {
-                    // Percentage values that do neither correlate to horrizontal nor vertical dimensions
+                    // Percentage values that do neither correlate to horizontal nor vertical dimensions
                     // need to be relative to the hypotenuse of both. Example: r="50%"
                     float sqr = sqrtf(viewBox[2] * viewBox[2] + viewBox[3] * viewBox[3]);
                     if (gradient.type == GradientType::kLinearGradient)

--- a/svgnative/src/SVGStringParser.h
+++ b/svgnative/src/SVGStringParser.h
@@ -23,9 +23,9 @@ namespace SVGStringParser
 {
 std::unique_ptr<Transform> ParseTransform(const std::string& transformString, std::function<std::unique_ptr<Transform>()> createTransform);
 bool ParseNumber(const std::string& numberString, float& number);
-bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptinoal = true);
+bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptional = true);
 bool ParseListOfLengthOrPercentage(
-    const std::string& lengthOrPercentageListString, float relDimensionLength, std::vector<float>& numberList, bool isAllOptinoal = true);
+    const std::string& lengthOrPercentageListString, float relDimensionLength, std::vector<float>& numberList, bool isAllOptional = true);
 bool ParseListOfStrings(const std::string& stringListString, std::vector<std::string>& stringList);
 bool ParseLengthOrPercentage(const std::string& lengthString, float relDimensionLength, float& absLengthInUnits, bool useQuirks = false);
 void ParsePathString(const std::string& pathString, Path& p);

--- a/svgnative/test/elem-transform-on-parent.svg
+++ b/svgnative/test/elem-transform-on-parent.svg
@@ -1,5 +1,5 @@
 <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g transform="roate(45)">
+    <g transform="rotate(45)">
         <rect id="ref" width="200" height="200" fill="green" />
     </g>
 </svg>

--- a/svgnative/test/path.svg
+++ b/svgnative/test/path.svg
@@ -19,7 +19,7 @@
     <path fill="green" d="m20,120,20,0l0,20,-20,0z"/>
     <path fill="green" d="m.4e2.12e3.2e2.0.0.2e2-.2e2.0z"/>
 
-    <!-- negetive tests -->
+    <!-- negative tests -->
     <!-- Comma before segment identifier supported by WebKit & Blink; not by spec -->
     <path fill="green" d="M60,120,L80,120,L80,140,L60,140,z"/>
     <!-- Comma right after segment identifier not supported anywhere -->

--- a/svgnative/test/properties.svg
+++ b/svgnative/test/properties.svg
@@ -7,7 +7,7 @@
     <line x1="5" y1="5" x2="145" y2="5" stroke-miterlimit="  
     0.5e2  "/>
 
-    <!-- stroke-miterlimit: negetive tests -->
+    <!-- stroke-miterlimit: negative tests -->
     <line x1="5" y1="5" x2="145" y2="5" stroke-miterlimit="-4"/>
     <line x1="5" y1="5" x2="145" y2="5" stroke-miterlimit="0"/>
     <line x1="5" y1="5" x2="145" y2="5" stroke-miterlimit="0.99"/>
@@ -25,7 +25,7 @@
     <line x1="5" y1="19" x2="145" y2="19" stroke="black" stroke-opacity="   
     2e-1  "/>
 
-    <!-- stroke-opacity: negetive tests -->
+    <!-- stroke-opacity: negative tests -->
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="20%"/>
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="2px"/>
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="2pc"/>
@@ -40,7 +40,7 @@
     <rect x="5" y="39" width="140" height="2" opacity="   
     2e-1  "/>
 
-    <!-- opacity: negetive tests -->
+    <!-- opacity: negative tests -->
     <rect x="5" y="40" width="140" height="2" opacity="20%"/>
     <rect x="5" y="40" width="140" height="2" opacity="2px"/>
     <rect x="5" y="40" width="140" height="2" opacity="2pc"/>
@@ -55,7 +55,7 @@
     <rect x="5" y="39" width="140" height="2" fill-opacity="   
     2e-1  "/>
 
-    <!-- fill-opacity: negetive tests -->
+    <!-- fill-opacity: negative tests -->
     <rect x="5" y="42" width="140" height="2" fill-opacity="20%"/>
     <rect x="5" y="42" width="140" height="2" fill-opacity="2px"/>
     <rect x="5" y="42" width="140" height="2" fill-opacity="2pc"/>
@@ -79,7 +79,7 @@
     <!-- stroke-width: reset stroke -->
     <line x2="200" y1="100" y2="100" stroke="black" stroke-width="0"/>
 
-    <!-- stroke-width: negetive tests -->
+    <!-- stroke-width: negative tests -->
     <line x2="200" y1="105" y2="105" stroke="black" stroke-width="-3.0e2"/>
     <line x2="200" y1="105" y2="105" stroke="black" stroke-width="-300.0e-2"/>
 </svg>

--- a/svgnative/test/svgLength.svg
+++ b/svgnative/test/svgLength.svg
@@ -22,7 +22,7 @@
     <ellipse cx="50%" cy="50%" rx="50%" ry="50%"/>
     <rect x="25%" y="25%" width="50%" height="50%"/>
 
-    <!-- negetive tests -->
+    <!-- negative tests -->
     <rect fill="red" x="50e" y="100" height="5" width="50"/>
     <rect fill="red" x="50pxx" y="105" height="5" width="50"/>
     <rect fill="red" x="50epx" y="110" height="5" width="50"/>


### PR DESCRIPTION
Mostly documentation and comments; notable exception:
`SVGDocumentImpl::LengthType::kHorrizontal` => `SVGDocumentImpl::LengthType::kHorizontal`

boundnig -> bounding (1x)
comercial -> commercial (1x)
consitent -> consistent (1x)
decendants -> descendants (1x)
desandents -> descendants (1x)
foramts -> formats (1x)
graohic -> graphic (1x)
habe -> have (1x)
hiearchy -> hierarchy (1x)
horrizontal -> horizontal (23x)
negetive -> negative (7x)
opacty -> opacity (1x)
optinoal -> optional (2x)
roate -> rotate (1x)
separaetd -> separated (2x)