### PR TITLE
Skia: Support fill-rule.

### DIFF
--- a/svgnative/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/ports/skia/SkiaSVGRenderer.cpp
@@ -191,11 +191,12 @@ void SkiaSVGRenderer::DrawPath(
     Save(graphicStyle);
     if (fillStyle.hasFill)
     {
-        // FIXME: Handle winding rules.
         SkPaint fill;
         fill.setStyle(SkPaint::kFill_Style);
         CreateSkPaint(fillStyle.paint, fillStyle.fillOpacity, fill);
-        mCanvas->drawPath(static_cast<const SkiaSVGPath&>(path).mPath, fill);
+        SkPath mPath = (static_cast<const SkiaSVGPath&>(path).mPath);
+        mPath.setFillType(fillStyle.fillRule == WindingRule::kNonZero ? SkPath::kWinding_FillType : SkPath::kEvenOdd_FillType);
+        mCanvas->drawPath(mPath, fill);
     }
     if (strokeStyle.hasStroke)
     {


### PR DESCRIPTION
For the side-by-side discussion for clip-rule and fill-rule, Skia port might be expected to support fill-rule. My patch call setFillType() method of SkPath object, before it is passed to drawPath().

I've checked their results by 2 samples at W3C's SVG spec page.

https://www.w3.org/TR/SVG11/images/painting/fillrule-nonzero.svg
is resulted as
![fillrule-nonzero skia](https://user-images.githubusercontent.com/2202675/68188979-c4775e00-ffed-11e9-9faf-cb25fe41b10b.png)

https://www.w3.org/TR/SVG11/images/painting/fillrule-evenodd.svg
is resulted as
![fillrule-evenodd skia](https://user-images.githubusercontent.com/2202675/68189026-e375f000-ffed-11e9-8266-3abced27d65f.png)

