### PR TITLE
Remove trailing spaces

### DIFF
--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -1,4 +1,4 @@
-#[[ 
+#[[
 cd build
 cmake -Bbuild/win64 -H. -G "Visual Studio 15 2017 Win64"
 cmake -Bbuild/win32 -H. -G "Visual Studio 15 2017"
@@ -53,14 +53,14 @@ CMAKE_DEPENDENT_OPTION(USE_GDIPLUS_EXAMPLE "GDI+ example app" TRUE "NOT LIB_ONLY
 CMAKE_DEPENDENT_OPTION(USE_CAIRO_EXAMPLE "Cairo example" TRUE "NOT LIB_ONLY;CAIRO" FALSE)
 
 ################################
-# setting for Cairo 
+# setting for Cairo
 ################################
 if(CAIRO)
     find_package(PkgConfig)
     include(FindCairo)
     if(NOT CAIRO_FOUND)
-        set(CAIRO_INCLUDE_DIRS "/usr/include/cairo")     
-        set(CAIRO_LIBRARIES "-lcairo")     
+        set(CAIRO_INCLUDE_DIRS "/usr/include/cairo")
+        set(CAIRO_LIBRARIES "-lcairo")
     endif()
 endif()
 

--- a/svgnative/ports/cairo/CairoSVGRenderer.cpp
+++ b/svgnative/ports/cairo/CairoSVGRenderer.cpp
@@ -68,14 +68,14 @@ void CairoSVGPath::Ellipse(float cx, float cy, float rx, float ry)
     // https://cairographics.org/cookbook/ellipses/
 
     cairo_matrix_t  save_matrix;
-    cairo_get_matrix(mPathCtx, &save_matrix); 
+    cairo_get_matrix(mPathCtx, &save_matrix);
 
     cairo_translate(mPathCtx, cx, cy);
     cairo_scale(mPathCtx, rx, ry);
     cairo_new_sub_path(mPathCtx);
     cairo_arc(mPathCtx, 0, 0, 1, 0, 2 * M_PI);
 
-    cairo_set_matrix(mPathCtx, &save_matrix); 
+    cairo_set_matrix(mPathCtx, &save_matrix);
 }
 
 void CairoSVGPath::MoveTo(float x, float y)
@@ -141,7 +141,7 @@ void CairoSVGTransform::Concat(const Transform& other)
     cairo_matrix_t  result;
     cairo_matrix_multiply(&result, &mMatrix, &(static_cast<const CairoSVGTransform&>(other).mMatrix));
     // Cairo has no simple API to copy a matrix to another
-    cairo_matrix_init(&mMatrix, result.xx, result.yx, result.xy, result.yy, result.x0, result.y0); 
+    cairo_matrix_init(&mMatrix, result.xx, result.yx, result.xy, result.yy, result.x0, result.y0);
 }
 
 CairoSVGImageData::CairoSVGImageData(const std::string& base64, ImageEncoding encoding)
@@ -308,7 +308,7 @@ inline void createCairoPattern(const Paint& paint, float opacity, cairo_pattern_
     if (gradient.transform)
         cairo_pattern_set_matrix(*pat, &(static_cast<CairoSVGTransform*>(gradient.transform.get())->mMatrix));
 
-    // set "stop"s of gradient 
+    // set "stop"s of gradient
     for (const auto& stop : gradient.colorStops)
     {
         // here, ColorStop is a pair of offset (in float) and color

--- a/svgnative/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/ports/cg/CGSVGRenderer.cpp
@@ -127,7 +127,7 @@ void CGSVGRenderer::Save(const GraphicStyle& graphicStyle)
             CGPathRelease(newPath);
         }
         else
-            CGContextAddPath(mContext, path);   
+            CGContextAddPath(mContext, path);
         if (graphicStyle.clippingPath->clipRule == WindingRule::kEvenOdd)
             CGContextEOClip(mContext);
         else

--- a/svgnative/ports/gdiplus/GDIPlusSVGRenderer.cpp
+++ b/svgnative/ports/gdiplus/GDIPlusSVGRenderer.cpp
@@ -34,15 +34,15 @@ Gdiplus::Color ColorToGdiplusColor(const Color& inColor)
 /******************************************************************************/
 
 GDIPlusSVGPath::GDIPlusSVGPath()
-{ 
+{
 }
 
-GDIPlusSVGPath::~GDIPlusSVGPath() 
-{ 
+GDIPlusSVGPath::~GDIPlusSVGPath()
+{
 }
 
-void GDIPlusSVGPath::Rect(float x, float y, float width, float height) 
-{ 
+void GDIPlusSVGPath::Rect(float x, float y, float width, float height)
+{
     mPath.AddRectangle(Gdiplus::RectF(x, y, width, height));
 }
 
@@ -98,8 +98,8 @@ void GDIPlusSVGPath::CurveToV(float x2, float y2, float x3, float y3)
     mCurrentY = y3;
 }
 
-void GDIPlusSVGPath::ClosePath() 
-{ 
+void GDIPlusSVGPath::ClosePath()
+{
     mPath.CloseFigure();
 }
 
@@ -110,28 +110,28 @@ const Gdiplus::GraphicsPath& GDIPlusSVGPath::GetGraphicsPath() const
 
 /******************************************************************************/
 
-GDIPlusSVGTransform::GDIPlusSVGTransform(float a, float b, float c, float d, float tx, float ty) 
-{ 
+GDIPlusSVGTransform::GDIPlusSVGTransform(float a, float b, float c, float d, float tx, float ty)
+{
     mTransform.SetElements(a, b, c, d, tx, ty);
 }
 
-void GDIPlusSVGTransform::Set(float a, float b, float c, float d, float tx, float ty) 
-{ 
+void GDIPlusSVGTransform::Set(float a, float b, float c, float d, float tx, float ty)
+{
     mTransform.SetElements(a, b, c, d, tx, ty);
 }
 
-void GDIPlusSVGTransform::Rotate(float r) 
-{ 
+void GDIPlusSVGTransform::Rotate(float r)
+{
     mTransform.Rotate(r);
 }
 
-void GDIPlusSVGTransform::Translate(float tx, float ty) 
-{ 
+void GDIPlusSVGTransform::Translate(float tx, float ty)
+{
     mTransform.Translate(tx, ty);
 }
 
-void GDIPlusSVGTransform::Scale(float sx, float sy) 
-{ 
+void GDIPlusSVGTransform::Scale(float sx, float sy)
+{
     mTransform.Scale(sx, sy);
 }
 
@@ -155,7 +155,7 @@ GDIPlusSVGImageData::GDIPlusSVGImageData(const std::string& base64, ImageEncodin
         if (imageData)
         {
             std::memcpy(imageData, imageString.c_str(), imageString.size());
-            
+
             IStream* pImageStream{};
             if (::CreateStreamOnHGlobal(hImageData, FALSE, &pImageStream) == S_OK)
             {
@@ -187,7 +187,7 @@ const std::unique_ptr<Gdiplus::Image>& GDIPlusSVGImageData::GetImage() const
     return mImage;
 }
 
-GDIPlusSVGRenderer::GDIPlusSVGRenderer() 
+GDIPlusSVGRenderer::GDIPlusSVGRenderer()
 {
 }
 
@@ -200,7 +200,7 @@ void GDIPlusSVGRenderer::Save(const GraphicStyle& graphicStyle)
         const Gdiplus::Matrix* matrix = &dynamic_cast<GDIPlusSVGTransform*>(graphicStyle.transform.get())->GetMatrix();
         if (matrix != nullptr)
         {
-            mContext->SetTransform(matrix);   
+            mContext->SetTransform(matrix);
         }
     }
 
@@ -415,14 +415,14 @@ void GDIPlusSVGRenderer::DrawImage(const ImageData& image, const GraphicStyle& g
     {
         Save(graphicStyle);
 
-        if (clipArea.width < fillArea.width || clipArea.height < fillArea.height)   
+        if (clipArea.width < fillArea.width || clipArea.height < fillArea.height)
         {
             mContext->SetClip(Gdiplus::RectF(clipArea.x, clipArea.y, clipArea.width, clipArea.height));
         }
 
         mContext->DrawImage(gdiPlusImage.GetImage().get(), Gdiplus::RectF(fillArea.x, 0, fillArea.width, fillArea.height));
 
-        Restore();  
+        Restore();
     }
 }
 

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -983,7 +983,7 @@ void SVGDocumentImpl::Render(const ColorMap& colorMap, float width, float height
     SVG_ASSERT(mGroup);
     if (!mGroup)
         return;
-    
+
     RenderElement(*mGroup, colorMap, width, height);
 }
 


### PR DESCRIPTION
I found some lines have unrequired trailing spaces (some of them are mine, I apologize them). Here is a patch removing trailing spaces from *.cpp, *.h, *.c and *.txt.