### PR TITLE
Add getOrientedImage() function to resolve the issue (#53).

### DIFF
--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -164,6 +164,9 @@ file(GLOB skia_port
     ports/skia/SkiaSVGRenderer.h
     ports/skia/SkiaSVGRenderer.cpp
 )
+if (NOT MSVC)
+    set_source_files_properties(ports/skia/SkiaSVGRenderer.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
+endif()
 endif()
 
 set(gdiplus_port)
@@ -221,6 +224,7 @@ target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR
 endif()
 if (USE_SKIA)
 target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ports/skia")
+target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/include/codec")
 target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/include/config")
 target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/include/core")
 target_include_directories(SVGNativeViewerLib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/include/effects")


### PR DESCRIPTION
* take <sk_sp>SkImage, return an oriented <sk_sp>SkImage or nullptr.

* determine the orientation from EXIF info, by using SkCodec.

* if the orientation is required, <sk_sp>SkImage is returned.

* if the orientation is not needed, nullptr is returned.

Add -Wno-pedantic (if not MSVC) to compile SkiaSVGRenderer.cpp,
because skcms.h (required by SkCodec.h) requires C11 feature.