### PR TITLE
Fix for Issue #63.

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -101,8 +101,7 @@ void SVGDocumentImpl::TraverseSVGTree()
 
 bool SVGDocumentImpl::HasAttr(XMLNode* node, const char* attrName)
 {
-    if (!node)
-        return false;
+    SVG_ASSERT(node != nullptr);
 
     auto attr = node->first_attribute(attrName);
     return attr != nullptr;
@@ -131,8 +130,7 @@ float SVGDocumentImpl::RelativeLength(LengthType lengthType) const
 
 float SVGDocumentImpl::ParseLengthFromAttr(XMLNode* node, const char* attrName, LengthType lengthType, float fallback)
 {
-    if (!node)
-        return fallback;
+    SVG_ASSERT(node != nullptr);
 
     auto attr = node->first_attribute(attrName);
     if (!attr)
@@ -147,8 +145,7 @@ float SVGDocumentImpl::ParseLengthFromAttr(XMLNode* node, const char* attrName, 
 
 void SVGDocumentImpl::ParseChildren(XMLNode* node)
 {
-    if (!node)
-        return;
+    SVG_ASSERT(node != nullptr);
 
     for (auto child = node->first_node(); child != nullptr; child = child->next_sibling())
     {
@@ -158,8 +155,7 @@ void SVGDocumentImpl::ParseChildren(XMLNode* node)
 
 void SVGDocumentImpl::ParseChild(XMLNode* child)
 {
-    if (!child)
-        return;
+    SVG_ASSERT(child != nullptr);
 
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
@@ -393,8 +389,7 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
 
 void SVGDocumentImpl::ParseResources(XMLNode* node)
 {
-    if (!node)
-        return;
+    SVG_ASSERT(node != nullptr);
 
     for (auto child = node->first_node(); child != nullptr; child = child->next_sibling())
     {
@@ -404,8 +399,7 @@ void SVGDocumentImpl::ParseResources(XMLNode* node)
 
 void SVGDocumentImpl::ParseResource(XMLNode* child)
 {
-    if (!child)
-        return;
+    SVG_ASSERT(child != nullptr);
 
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
@@ -477,8 +471,7 @@ void SVGDocumentImpl::ParseResource(XMLNode* child)
 
 std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
 {
-    if (!child)
-        return nullptr;
+    SVG_ASSERT(child != nullptr);
 
     std::string elementName = child->name();
     if (elementName == "rect")
@@ -860,9 +853,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
 
 float SVGDocumentImpl::ParseColorStop(XMLNode* node, std::vector<ColorStopImpl>& colorStops, float lastOffset)
 {
-    /* XXX */
-    if (!node)
-        return 0;
+    SVG_ASSERT(node != nullptr);
 
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
@@ -892,8 +883,7 @@ float SVGDocumentImpl::ParseColorStop(XMLNode* node, std::vector<ColorStopImpl>&
 
 void SVGDocumentImpl::ParseColorStops(XMLNode* node, GradientImpl& gradient)
 {
-    if (!node)
-        return;
+    SVG_ASSERT(node != nullptr);
 
     // Return early if we don't have children.
     if (!node->first_node())
@@ -924,8 +914,7 @@ void SVGDocumentImpl::ParseColorStops(XMLNode* node, GradientImpl& gradient)
 
 void SVGDocumentImpl::ParseGradient(XMLNode* node)
 {
-    if (!node)
-        return;
+    SVG_ASSERT(node != nullptr);
 
     GradientImpl gradient{};
 

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -60,7 +60,7 @@ SVGDocumentImpl::SVGDocumentImpl(std::shared_ptr<SVGRenderer> renderer)
 void SVGDocumentImpl::TraverseSVGTree()
 {
     auto rootNode = mXMLDocument.first_node();
-    if (std::string(rootNode->name()) != "svg")
+    if (!rootNode || std::string(rootNode->name()) != "svg")
         return;
 
     if (!HasAttr(rootNode, "viewBox"))
@@ -101,6 +101,9 @@ void SVGDocumentImpl::TraverseSVGTree()
 
 bool SVGDocumentImpl::HasAttr(XMLNode* node, const char* attrName)
 {
+    if (!node)
+        return false;
+
     auto attr = node->first_attribute(attrName);
     return attr != nullptr;
 }
@@ -128,6 +131,9 @@ float SVGDocumentImpl::RelativeLength(LengthType lengthType) const
 
 float SVGDocumentImpl::ParseLengthFromAttr(XMLNode* node, const char* attrName, LengthType lengthType, float fallback)
 {
+    if (!node)
+        return fallback;
+
     auto attr = node->first_attribute(attrName);
     if (!attr)
         return fallback;
@@ -141,6 +147,9 @@ float SVGDocumentImpl::ParseLengthFromAttr(XMLNode* node, const char* attrName, 
 
 void SVGDocumentImpl::ParseChildren(XMLNode* node)
 {
+    if (!node)
+        return;
+
     for (auto child = node->first_node(); child != nullptr; child = child->next_sibling())
     {
         ParseChild(child);
@@ -149,6 +158,9 @@ void SVGDocumentImpl::ParseChildren(XMLNode* node)
 
 void SVGDocumentImpl::ParseChild(XMLNode* child)
 {
+    if (!child)
+        return;
+
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
     std::set<std::string> classNames;
@@ -381,6 +393,9 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
 
 void SVGDocumentImpl::ParseResources(XMLNode* node)
 {
+    if (!node)
+        return;
+
     for (auto child = node->first_node(); child != nullptr; child = child->next_sibling())
     {
         ParseResource(child);
@@ -389,6 +404,9 @@ void SVGDocumentImpl::ParseResources(XMLNode* node)
 
 void SVGDocumentImpl::ParseResource(XMLNode* child)
 {
+    if (!child)
+        return;
+
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
     std::set<std::string> classNames;
@@ -459,6 +477,9 @@ void SVGDocumentImpl::ParseResource(XMLNode* child)
 
 std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
 {
+    if (!child)
+        return nullptr;
+
     std::string elementName = child->name();
     if (elementName == "rect")
     {
@@ -587,6 +608,8 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
 GraphicStyleImpl SVGDocumentImpl::ParseGraphic(
     XMLNode* node, FillStyleImpl& fillStyle, StrokeStyleImpl& strokeStyle, std::set<std::string>& classNames)
 {
+    SVG_ASSERT(node != nullptr);
+
     std::vector<PropertySet> propertySets;
     propertySets.push_back(ParsePresentationAttributes(node));
     ParseStyleAttr(node, propertySets, classNames);
@@ -614,6 +637,8 @@ GraphicStyleImpl SVGDocumentImpl::ParseGraphic(
 
 PropertySet SVGDocumentImpl::ParsePresentationAttributes(XMLNode* node)
 {
+    SVG_ASSERT(node != nullptr);
+
     PropertySet propertySet;
     auto attributeHandler = [&](const std::string& propertyName) {
         auto attr = node->first_attribute(propertyName.c_str());
@@ -835,6 +860,10 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
 
 float SVGDocumentImpl::ParseColorStop(XMLNode* node, std::vector<ColorStopImpl>& colorStops, float lastOffset)
 {
+    /* XXX */
+    if (!node)
+        return 0;
+
     auto fillStyle = mFillStyleStack.top();
     auto strokeStyle = mStrokeStyleStack.top();
     std::set<std::string> classNames;
@@ -863,6 +892,9 @@ float SVGDocumentImpl::ParseColorStop(XMLNode* node, std::vector<ColorStopImpl>&
 
 void SVGDocumentImpl::ParseColorStops(XMLNode* node, GradientImpl& gradient)
 {
+    if (!node)
+        return;
+
     // Return early if we don't have children.
     if (!node->first_node())
         return;
@@ -892,6 +924,9 @@ void SVGDocumentImpl::ParseColorStops(XMLNode* node, GradientImpl& gradient)
 
 void SVGDocumentImpl::ParseGradient(XMLNode* node)
 {
+    if (!node)
+        return;
+
     GradientImpl gradient{};
 
     // SVG allows referencing other gradients. For now, we only look at already parsed


### PR DESCRIPTION
* SVGDocumentImpl.cpp: Check whether the XMLNode is valid before using it.