### PR TITLE
Fix for Issue #64.

### DIFF
--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -404,6 +404,7 @@ void ParsePathString(const std::string& pathString, Path& p)
             return;
         if (!isDigit(*pos) && *pos != ',' && *pos != '-' && *pos != '.')
             prev = *pos++;
+        SVG_PARSE_TRACE("previous operator: " << prev);
         switch (prev)
         {
         case 'M':
@@ -455,6 +456,7 @@ void ParsePathString(const std::string& pathString, Path& p)
                 currentY = startY;
             }
 
+            prev = *pos++;
             break;
         case 'L':
             if (!ParseCoordinatePair(pos, end, currentX, currentY))


### PR DESCRIPTION
* SVGStringParser.cpp: increment the cursor 'pos' after taking 'Z' or 'z' operator, to prevent endless loop reported by Issue #64.