### PR TITLE
Disable rendering when we are close to 0 for dimension attributes on …

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -16,6 +16,7 @@ governing permissions and limitations under the License.
 #include "SVGStringParser.h"
 
 #include <cmath>
+#include <limits>
 
 namespace SVGNative
 {
@@ -55,6 +56,12 @@ SVGDocumentImpl::SVGDocumentImpl(std::shared_ptr<SVGRenderer> renderer)
     std::set<std::string> classNames;
     mGroup = std::make_shared<Group>(graphicStyle, classNames);
     mGroupStack.push(mGroup);
+}
+
+template <typename T>
+bool isCloseToZero(T x)
+{
+    return std::abs(x) < std::numeric_limits<T>::epsilon();
 }
 
 void SVGDocumentImpl::TraverseSVGTree()
@@ -468,6 +475,10 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
         float width = ParseLengthFromAttr(child, "width", LengthType::kHorizontal);
         float height = ParseLengthFromAttr(child, "height", LengthType::kVertical);
 
+        // SVG requires to disable rendering if width or height are 0.
+        if (isCloseToZero(width) || isCloseToZero(height))
+            return nullptr;
+
         bool hasRx = HasAttr(child, "rx");
         bool hasRy = HasAttr(child, "ry");
 
@@ -502,13 +513,13 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
         ry = std::min(ry, height / 2.0f);
 
         auto path = mRenderer->CreatePath();
+        // TODO: Create path for rectangle if rx != ry.
         if (rx == 0 && ry == 0)
         {
             path->Rect(x, y, width, height);
         }
         else
         {
-            SVG_ASSERT(rx == ry);
             path->RoundedRect(x, y, width, height, std::max(rx, ry));
         }
         return path;
@@ -527,6 +538,10 @@ std::unique_ptr<Path> SVGDocumentImpl::ParseShape(XMLNode* child)
             rx = ParseLengthFromAttr(child, "r", LengthType::kDiagonal);
             ry = rx;
         }
+
+        // SVG requires to disable rendering if rx or ry are 0.
+        if (isCloseToZero(rx) || isCloseToZero(ry))
+            return nullptr;
 
         float cx = ParseLengthFromAttr(child, "cx", LengthType::kHorizontal);
         float cy = ParseLengthFromAttr(child, "cy", LengthType::kVertical);

--- a/svgnative/test/shapes.svg
+++ b/svgnative/test/shapes.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="250" viewBox="0 0 150 250">
+    <!-- test that we disable rendering for certain values close to 0 -->
+    <rect width="1" height="1"/>
+    <rect width="1e20" height="1"/>
+    <rect width="1" height="1e20"/>
+    <rect width="1e40" height="1"/>
+    <rect width="1" height="1e40"/>
+    <rect width="1e60" height="1"/>
+    <rect width="1" height="1e60"/>
+    <rect width="0" height="1"/>
+    <rect width="1" height="0"/>
+    <ellipse rx="1" ry="1"/>
+    <ellipse rx="1e20" ry="1"/>
+    <ellipse rx="1" ry="1e20"/>
+    <ellipse rx="1e40" ry="1"/>
+    <ellipse rx="1" ry="1e40"/>
+    <ellipse rx="1e60" ry="1"/>
+    <ellipse rx="1" ry="1e60"/>
+    <ellipse rx="0" ry="1"/>
+    <ellipse rx="1" ry="0"/>
+    <circle r="1"/>
+    <circle r="1e20"/>
+    <circle r="1e40"/>
+    <circle r="1e60"/>
+    <circle r="0"/>
+</svg>

--- a/svgnative/test/shapes.txt
+++ b/svgnative/test/shapes.txt
@@ -1,0 +1,28 @@
+[group transform: matrix(1,0,0,1,0,0)
+    [group
+        [path Rect(0,0,1,1)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,0,1e+20,1)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Rect(0,0,1,1e+20)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Ellipse(0,0,1,1)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Ellipse(0,0,1e+20,1)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Ellipse(0,0,1,1e+20)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Ellipse(0,0,1,1)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+        [path Ellipse(0,0,1e+20,1e+20)
+            fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+            stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+    ]
+]


### PR DESCRIPTION
…circle, ellipse and rect.

I am using epsilon to determine if we are close to 0. We could support smaller values around 0 but anything smaller than that is less likely to occur in the real world but more likely to cause issues in any of the rendering libraries.

Fixes issues: #69, #67