### PR TITLE
Conditionalize JCS_EXT_ARGB, because it is an extension in JPEG-Turbo.

### DIFF
--- a/svgnative/ports/cairo/CairoImageInfo.c
+++ b/svgnative/ports/cairo/CairoImageInfo.c
@@ -73,9 +73,11 @@ _cairo_image_surface_create_from_jpeg_stream(const unsigned char* data,
         /* Cairo has no special format for grayscale, we must use RGB24 */
         cairo_color_format = CAIRO_FORMAT_RGB24;
         break;
+#ifdef JCS_EXT_ARGB
     case JCS_EXT_ARGB:
         cairo_color_format = CAIRO_FORMAT_ARGB32;
         break;
+#endif
     case JCS_RGB:
     default:
         cairo_color_format = CAIRO_FORMAT_RGB24;


### PR DESCRIPTION
When a developer tries to build SVG Native Viewer with Cairo port, and if their system has IJS's genuine JPEG not JPEG-Turbo, the building would be stopped because JCS_EXT_ARGB is not defined. It is JPEG-Turbo extension.

This attribute is determined from input JPEG image by JPEG decoder, the client program cannot specify it. If the client program pass an extended JPEG image with alpha-channel but the library is linked to IJS JPEG decoder, the image would be dealt as broken data, so, we don't have to write special workaround.