### PR TITLE
Add "make install" target, and to-be-installed & uninstalled pkg-config files (originally PR #60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 svgnative/build/
 viewer/
 .vscode
+SVGNativeViewerLib.pc

--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -59,15 +59,29 @@ CMAKE_DEPENDENT_OPTION(USE_SKIA_EXAMPLE "Skia" TRUE "NOT LIB_ONLY;SKIA" FALSE)
 CMAKE_DEPENDENT_OPTION(USE_GDIPLUS_EXAMPLE "GDI+ example app" TRUE "NOT LIB_ONLY;GDIPLUS" FALSE)
 CMAKE_DEPENDENT_OPTION(USE_CAIRO_EXAMPLE "Cairo example" TRUE "NOT LIB_ONLY;CAIRO" FALSE)
 
+find_package(PkgConfig)
+
 ################################
 # setting for Cairo
 ################################
 if(CAIRO)
-    find_package(PkgConfig)
+    # cmake wants to have full pathname of libcairo, instead of compiler flags.
+    # thus FindCairo.cmake works better than pkg_check_modules(CAIRO cairo)
     include(FindCairo)
     if(NOT CAIRO_FOUND)
-        set(CAIRO_INCLUDE_DIRS "/usr/include/cairo")
-        set(CAIRO_LIBRARIES "-lcairo")
+        message(FATAL_ERROR "Fatal error: Cairo port is requested, but CAIRO developers' files are missing.")
+    else()
+       # FindJPEG.cmake does not use pkg-config, we do as FindCairo.cmake.
+       pkg_check_modules(PC_JPEG libjpeg)
+       if (PC_JPEG_FOUND)
+           FIND_PATH(JPEG_INCLUDE_DIRS NAMES jpeglib.h HINTS ${PC_JPEG_INCLUDEDIR})
+           FIND_LIBRARY(JPEG_LIBRARY NAMES jpeg HINTS ${PC_JPEG_LIBDIR})
+       else()
+           include(FindJPEG)
+       endif()
+       if (NOT PC_JPEG_FOUND AND NOT JPEG_FOUND)
+           message(FATAL_ERROR "Fatal error: Cairo port requires LIBJPEG developers' files.")
+       endif()
     endif()
 endif()
 
@@ -157,15 +171,18 @@ file(GLOB gl_deprecated_styling
 )
 endif()
 
-##############################
-# Rendering ports
-##############################
+#####################################################
+# Rendering ports, and collect gl_headers to install
+#####################################################
+file(GLOB gl_headers ${PROJECT_SOURCE_DIR}/include/*.h)
+
 set(text_port)
 if(USE_TEXT)
 file(GLOB text_port
     ports/string/StringSVGRenderer.h
     ports/string/StringSVGRenderer.cpp
 )
+set(gl_headers ${gl_headers} ${PROJECT_SOURCE_DIR}/ports/string/StringSVGRenderer.h)
 endif()
 
 set(cg_port)
@@ -176,6 +193,7 @@ file(GLOB cg_port
     ../third_party/cpp-base64/base64.h
     ../third_party/cpp-base64/base64.cpp
 )
+set(gl_headers ${gl_headers} ${PROJECT_SOURCE_DIR}/ports/cg/CGSVGRenderer.h)
 endif()
 
 set(skia_port)
@@ -184,6 +202,7 @@ file(GLOB skia_port
     ports/skia/SkiaSVGRenderer.h
     ports/skia/SkiaSVGRenderer.cpp
 )
+set(gl_headers ${gl_headers} ${PROJECT_SOURCE_DIR}/ports/skia/SkiaSVGRenderer.h)
 if (NOT MSVC)
     set_source_files_properties(ports/skia/SkiaSVGRenderer.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
 endif()
@@ -197,6 +216,7 @@ file(GLOB gdiplus_port
     ../third_party/cpp-base64/base64.h
     ../third_party/cpp-base64/base64.cpp
 )
+set(gl_headers ${gl_headers} ${PROJECT_SOURCE_DIR}/ports/gdiplus/GDIPlusSVGRenderer.h)
 endif()
 set(cairo_port)
 if (USE_CAIRO)
@@ -208,6 +228,7 @@ file(GLOB cairo_port
     ../third_party/cpp-base64/base64.h
     ../third_party/cpp-base64/base64.cpp
 )
+set(gl_headers ${gl_headers} ${PROJECT_SOURCE_DIR}/ports/cairo/CairoSVGRenderer.h)
 endif()
 
 ##############################
@@ -268,20 +289,51 @@ endif()
 ##############################
 # Library search paths
 ##############################
+set(PRIVATE_LIBS)
+set(REQUIRES)
+set(PRIVATE_REQUIRES)
+set(PORTS_INCLUDES)
 
 if(USE_CG)
-target_link_libraries(SVGNativeViewerLib "-framework CoreGraphics")
+    target_link_libraries(SVGNativeViewerLib "-framework CoreGraphics")
+    set(PRIVATE_LIBS "${PRIVATE_LIBS} -framework CoreGraphics")
+    set(PORTS_INCLUDES "${PORTS_INCLUDES} -I\${includedir}/ports/cg")
 endif()
+
 if (USE_SKIA)
-if(MSVC)
-target_link_libraries(SVGNativeViewerLib "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/skia.lib")
-else()
-target_link_libraries(SVGNativeViewerLib "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/osx/libskia.a")
+    if(MSVC)
+        target_link_libraries(SVGNativeViewerLib "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/skia.lib")
+        set(PRIVATE_LIBS "${PRIVATE_LIBS} -L${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/ -lskia")
+    else()
+        target_link_libraries(SVGNativeViewerLib "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/osx/libskia.a")
+        # XXX: how to list the libraries which libskia.a depends?
+        set(PRIVATE_LIBS "${PRIVATE_LIBS} -L${CMAKE_CURRENT_SOURCE_DIR}/../third_party/skia/lib/osx/ -lskia")
+    endif()
+    set(PORTS_INCLUDES "${PORTS_INCLUDES} -I\${includedir}/ports/skia")
 endif()
-endif()
+
 if (USE_CAIRO)
-target_link_libraries(SVGNativeViewerLib "${CAIRO_LIBRARIES}")
-target_link_libraries(SVGNativeViewerLib "-ljpeg")
+    target_link_libraries(SVGNativeViewerLib "${CAIRO_LIBRARIES}")
+    target_link_libraries(SVGNativeViewerLib "${JPEG_LIBRARY}")
+    target_include_directories(SVGNativeViewerLib PUBLIC "${CAIRO_INCLUDE_DIRS}")
+    target_include_directories(SVGNativeViewerLib PRIVATE "${JPEG_INCLUDE_DIRS}")
+    set(PRIVATE_REQUIRES "${PRIVATE_REQUIRES} cairo")
+    set(PORTS_INCLUDES "${PORTS_INCLUDES} -I\${includedir}/ports/cairo")
+
+    # sometimes JPEG is not managed by pkg-config
+    if (PC_JPEG_FOUND)
+        set(PRIVATE_REQUIRES "${PRIVATE_REQUIRES} libjpeg")
+    else()
+        get_filename_component(JPEG_LIBRARY_DIR ${JPEG_LIBRARY} DIRECTORY)
+        set(PRIVATE_LIBS "${PRIVATE_LIBS} -L${JPEG_LIBRARY_DIR} -ljpeg")
+    endif()
+endif()
+
+# CMake has no additional file to record the dependency for the static library,
+# we have to put direct dependencies into pkg-config files.
+if (NOT USE_SHARED)
+    set(REQUIRES "${PRIVATE_REQUIRES}")
+    set(PRIVATE_REQUIRES "")
 endif()
 
 set_target_properties(SVGNativeViewerLib PROPERTIES LINKER_LANGUAGE CXX)
@@ -297,9 +349,46 @@ endif()
 ##############################
 # Creating pkg-config file
 ##############################
+include(GNUInstallDirs)
 
-# TODO: Add includes and libraries for individual ports.
 set(BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(PRIVATE_LIBS)
-CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib.pc.in" "${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib.pc" @ONLY)
+set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+set(PRIVATE_LIBS "${PRIVATE_LIBS}")
+set(REQUIRES "${REQUIRES}")
+set(PRIVATE_REQUIRES "${PRIVATE_REQUIRES}")
+set(PORTS_INCLUDES "${PORTS_INCLUDES}")
+set(HEADER_SUBDIR "svgnative")
+CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/SVGNativeViewerLib.pc" @ONLY)
+CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib-uninstalled.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/SVGNativeViewerLib-uninstalled.pc" @ONLY)
+
+##############################
+# Installation
+##############################
+
+# library
+install(
+    TARGETS SVGNativeViewerLib
+    EXPORT SVGNativeViewerLib-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT libraries)
+
+# headers
+install(
+    FILES ${gl_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_SUBDIR}
+    COMPONENT headers)
+
+# pkg-config file
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/SVGNativeViewerLib.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT pkgconfig)
+

--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -293,3 +293,13 @@ if(NOT Boost_FOUND)
 else()
     target_include_directories(SVGNativeViewerLib PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
+
+##############################
+# Creating pkg-config file
+##############################
+
+# TODO: Add includes and libraries for individual ports.
+set(BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(PRIVATE_LIBS)
+CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib.pc.in" "${CMAKE_CURRENT_SOURCE_DIR}/SVGNativeViewerLib.pc" @ONLY)

--- a/svgnative/SVGNativeViewerLib-uninstalled.pc.in
+++ b/svgnative/SVGNativeViewerLib-uninstalled.pc.in
@@ -1,0 +1,14 @@
+prefix=@SOURCE_DIR@
+exec_prefix=@BINARY_DIR@
+libdir=${exec_prefix}
+includedir=${prefix}/include
+
+Name: SVGNativeViewerLib
+Description: Parser and renderer for SVG Native documents
+Version: @VERSION@
+Requires: @REQUIRES@
+Requires.private: @PRIVATE_REQUIRES@
+
+Cflags: -I${includedir} @PORTS_INCLUDES@
+Libs: -L${libdir} -lSVGNativeViewerLib
+Libs.private: @PRIVATE_LIBS@

--- a/svgnative/SVGNativeViewerLib.pc.in
+++ b/svgnative/SVGNativeViewerLib.pc.in
@@ -1,10 +1,14 @@
-prefix=@SOURCE_DIR@
-exec_prefix=@BINARY_DIR@
-libdir=${exec_prefix}
-includedir=${prefix}/include
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@HEADER_SUBDIR@
 
 Name: SVGNativeViewerLib
 Description: Parser and renderer for SVG Native documents
 Version: @VERSION@
+Requires: @REQUIRES@ 
+Requires.private: @PRIVATE_REQUIRES@
 
 Cflags: -I${includedir}
+Libs: -L${libdir} -lSVGNativeViewerLib
+Libs.private: @PRIVATE_LIBS@

--- a/svgnative/SVGNativeViewerLib.pc.in
+++ b/svgnative/SVGNativeViewerLib.pc.in
@@ -1,0 +1,10 @@
+prefix=@SOURCE_DIR@
+exec_prefix=@BINARY_DIR@
+libdir=${exec_prefix}
+includedir=${prefix}/include
+
+Name: SVGNativeViewerLib
+Description: Parser and renderer for SVG Native documents
+Version: @VERSION@
+
+Cflags: -I${includedir}


### PR DESCRIPTION
* Enhancements for pkg-config files. Add "make install" target into CMakeLists.txt,
  to separate SVGNativeViewerLib.pc and SVGNativeViewerLib-uninstalled.pc.

* Cairo and JPEG check is improved for non-Unix platforms.