### PR TITLE
CoreGraphics port: add "-framework CoreFoundation" to the linker flag to use libSVGNativeViewerLib.

### DIFF
--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -314,7 +314,8 @@ set(PORTS_INCLUDES)
 
 if(USE_CG)
     target_link_libraries(SVGNativeViewerLib "-framework CoreGraphics")
-    set(PRIVATE_LIBS "${PRIVATE_LIBS} -framework CoreGraphics")
+    target_link_libraries(SVGNativeViewerLib "-framework CoreFoundation")
+    set(PRIVATE_LIBS "${PRIVATE_LIBS} -framework CoreGraphics -framework CoreFoundation")
     set(PORTS_INCLUDES "${PORTS_INCLUDES} -I\${includedir}/ports/cg")
 endif()
 


### PR DESCRIPTION
d1f8a2c cannot finish the linking of testC. To finish it, "-framework CoreFoundation" is added to the linker flag in CMakeLists.txt.
An archive library does no record its dependency, so the dependencies should be supplied by the linker flags explicitly, also it is added to pkg-config file.