### PR TITLE
include Win32 headers to compile SVGNativeCWrapper.cpp with GDI+.

### DIFF
--- a/svgnative/src/SVGNativeCWrapper.cpp
+++ b/svgnative/src/SVGNativeCWrapper.cpp
@@ -22,6 +22,8 @@ governing permissions and limitations under the License.
 #include <CoreGraphics/CoreGraphics.h>
 #endif
 #ifdef USE_GDIPLUS
+#include <windows.h>
+#include <Gdiplus.h>
 #include "GDIPlusSVGRenderer.h"
 #endif
 #ifdef USE_SKIA


### PR DESCRIPTION
It seems that [SVGNativeCWrapper compile error around GDI+ header](https://circleci.com/gh/adobe/svg-native-viewer/655?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) might be caused by the lack of a few header files. I apologize that I could not find this error before.