### PR TITLE
fix GDIPlus under -DSHARED=ON config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
             $cmakeVersion = "3.16.2"
             $env:Path += ";" + (Get-Item -Path ".\").FullName + "\cmake-" + $cmakeVersion + "-win64-x64\bin"
             cd .\svgnative
-            cmake -Bbuild/win-shared . -G "Visual Studio 16 2019" -DSHARED=ON
+            cmake -Bbuild/win-shared . -G "Visual Studio 16 2019" -DGDIPLUS=ON -DSHARED=ON
       - run:
           name: Creating Binary Files - Shared Lib
           command: |

--- a/svgnative/CMakeLists.txt
+++ b/svgnative/CMakeLists.txt
@@ -338,6 +338,11 @@ if (USE_SKIA)
     set(PORTS_INCLUDES "${PORTS_INCLUDES} -I\${includedir}/ports/skia")
 endif()
 
+if (USE_GDIPLUS)
+    target_link_libraries(SVGNativeViewerLib "gdiplus.lib")
+    set(PRIVATE_LIBS "${PRIVATE_LIBS} gdiplus.lib")
+endif()
+
 if (USE_CAIRO)
     target_link_libraries(SVGNativeViewerLib "${CAIRO_LIBRARIES}")
     target_link_libraries(SVGNativeViewerLib "${JPEG_LIBRARY}")

--- a/svgnative/ports/gdiplus/GDIPlusSVGRenderer.cpp
+++ b/svgnative/ports/gdiplus/GDIPlusSVGRenderer.cpp
@@ -192,6 +192,21 @@ GDIPlusSVGRenderer::GDIPlusSVGRenderer()
 {
 }
 
+std::unique_ptr<ImageData> GDIPlusSVGRenderer::CreateImageData(const std::string& base64, ImageEncoding encoding)
+{
+    return std::unique_ptr<GDIPlusSVGImageData>(new GDIPlusSVGImageData(base64, encoding));
+}
+
+std::unique_ptr<Path> GDIPlusSVGRenderer::CreatePath()
+{
+    return std::unique_ptr<GDIPlusSVGPath>(new GDIPlusSVGPath);
+}
+
+std::unique_ptr<Transform> GDIPlusSVGRenderer::CreateTransform(float a, float b, float c, float d, float tx, float ty)
+{
+    return std::unique_ptr<GDIPlusSVGTransform>(new GDIPlusSVGTransform(a, b, c, d, tx, ty));
+}
+
 void GDIPlusSVGRenderer::Save(const GraphicStyle& graphicStyle)
 {
     mStateStack.push_back(mContext->Save());

--- a/svgnative/ports/gdiplus/GDIPlusSVGRenderer.h
+++ b/svgnative/ports/gdiplus/GDIPlusSVGRenderer.h
@@ -83,21 +83,12 @@ public:
     { 
     }
 
-    std::unique_ptr<ImageData> CreateImageData(const std::string& base64, ImageEncoding encoding) override 
-    { 
-        return std::unique_ptr<GDIPlusSVGImageData>(new GDIPlusSVGImageData(base64, encoding)); 
-    }
+    std::unique_ptr<ImageData> CreateImageData(const std::string& base64, ImageEncoding encoding) override;
 
-    std::unique_ptr<Path> CreatePath() override 
-    { 
-        return std::unique_ptr<GDIPlusSVGPath>(new GDIPlusSVGPath); 
-    }
+    std::unique_ptr<Path> CreatePath() override;
 
     std::unique_ptr<Transform> CreateTransform(
-        float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) override
-    {
-        return std::unique_ptr<GDIPlusSVGTransform>(new GDIPlusSVGTransform(a, b, c, d, tx, ty));
-    }
+        float a = 1.0, float b = 0.0, float c = 0.0, float d = 1.0, float tx = 0.0, float ty = 0.0) override;
 
     void Save(const GraphicStyle& graphicStyle) override;
     void Restore() override;


### PR DESCRIPTION
Fix for the issue #96.
* CMakeLists.txt: add explicit dependency to gdiplus.dll.
* GDIPlusSVGRenderer.{h,cpp}: move several inline functions from header to C++ source.
some Windows headers makes the symbol references from the inline functions in the class definition,
even if such functions are not used at all.