### PR TITLE
TestMain.c: change the license to APL 2.0

### DIFF
--- a/svgnative/example/testC/TestMain.c
+++ b/svgnative/example/testC/TestMain.c
@@ -1,21 +1,17 @@
-/*************************************************************************
- * ADOBE CONFIDENTIAL
- * ___________________
- *
- * Copyright 2019 Adobe
- * Copyright 2019 suzuki toshiya <mpsuzuki@hiroshima-u.ac.jp>
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains
- * the property of Adobe and its suppliers,
- * if any. The intellectual and technical concepts contained
- * herein are proprietary to Adobe and its
- * suppliers and are protected by all applicable intellectual property
- * laws, including trade secret and copyright laws.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe.
- **************************************************************************/
+/*
+Copyright 2019 Adobe.
+Copyright 2019 suzuki toshiya <mpsuzuki@hiroshima-u.ac.jp>.
+All rights reserved.
+
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Maybe it was my mistake that "Adobe Confidential" license is used in TestMain.c.
Using Apache License 2.0 would be better and consistent.