### PR TITLE
Fix for Issue #111: a valid fill attribute cannot override its parental "fill='none'" attribute.

### DIFF
--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -1031,14 +1031,14 @@ SVGDocumentImpl::Result ParseColor(const std::string& colorString, ColorImpl& pa
 SVGDocumentImpl::Result ParsePaint(const std::string& colorString, const std::map<std::string, GradientImpl>& gradientMap,
     const std::array<float, 4>& viewBox, PaintImpl& paint)
 {
-    SVGDocumentImpl::Result result{SVGDocumentImpl::Result::kInvalid};
+    SVGDocumentImpl::Result result{SVGDocumentImpl::Result::kSuccess};
     if (!colorString.size())
-        return result;
+        return SVGDocumentImpl::Result::kInvalid;
 
     auto pos = colorString.begin();
     auto end = colorString.end();
     if (!SkipOptWsp(pos, end))
-        return result;
+        return SVGDocumentImpl::Result::kInvalid;
 
     SVGDocumentImpl::Result urlResult{SVGDocumentImpl::Result::kInvalid};
     if (std::distance(pos, end) >= 5)


### PR DESCRIPTION
SVGStringParser::ParsePaint() sets the initial value of 'result' to kInvalid. In some cases, the result is updated to kDisabled, but it is never updated to kSuccess, except of the case that ParseColor() updates it. Therefore, once the parental element sets "fill='none'", often the child elements cannot override it, like Issue #111.

This commit changes the initial value from kInvalid to kSuccess, and all 'return result' before changing 'result' are replaced by immediate 'return kInvalid'.