### PR TITLE
Fix incorrect 'T'/'t' implementation

### DIFF
--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -391,6 +391,7 @@ void ParsePathString(const std::string& pathString, Path& p)
     float prevControlY{}; // nanf(nullptr);
     float prevCurvePointX{};
     float prevCurvePointY{};
+    char lastCommand = 'm';
     char prev = 'm';
     // First segment must be a moveTo
     if (!SkipOptWsp(pos, end) || (*pos != 'm' && *pos != 'M'))
@@ -629,9 +630,14 @@ void ParsePathString(const std::string& pathString, Path& p)
             if (!ParseCoordinatePair(pos, end, nextX, nextY))
                 return;
 
-            // reflect previous control point
-            prevCurvePointX = currentX + (currentX - prevCurvePointX);
-            prevCurvePointY = currentY + (currentY - prevCurvePointY);
+            if (lastCommand != 'T' && lastCommand != 't' && lastCommand != 'Q' && lastCommand != 'q') {
+                prevCurvePointX = currentX;
+                prevCurvePointY = currentY;
+            } else {
+                // reflect previous control point
+                prevCurvePointX = currentX + (currentX - prevCurvePointX);
+                prevCurvePointY = currentY + (currentY - prevCurvePointY);
+            }
 
             p.CurveToV(prevCurvePointX, prevCurvePointY, nextX, nextY);
 
@@ -651,9 +657,14 @@ void ParsePathString(const std::string& pathString, Path& p)
             nextX += currentX;
             nextY += currentY;
 
-            // reflect previous control point
-            prevCurvePointX = currentX + (currentX - prevCurvePointX);
-            prevCurvePointY = currentY + (currentY - prevCurvePointY);
+            if (lastCommand != 'T' && lastCommand != 't' && lastCommand != 'Q' && lastCommand != 'q') {
+                prevCurvePointX = currentX;
+                prevCurvePointY = currentY;
+            } else {
+                // reflect previous control point
+                prevCurvePointX = currentX + (currentX - prevCurvePointX);
+                prevCurvePointY = currentY + (currentY - prevCurvePointY);
+            }
 
             p.CurveToV(prevCurvePointX, prevCurvePointY, nextX, nextY);
 
@@ -718,6 +729,8 @@ void ParsePathString(const std::string& pathString, Path& p)
             break;
         }
         }
+
+        lastCommand = prev;
     }
 }
 


### PR DESCRIPTION
According to the [spec](https://www.w3.org/TR/SVG/paths.html#PathDataQuadraticBezierCommands), the 'T' and 't' only use the reflection of the last control point if the last command is Q/q/T/t

Following is an SVG that contains a character "c", without the patch it renders incorrectly:
```
<svg
  xmlns="http://www.w3.org/2000/svg" width="108.21ex" height="24.52ex" role="img" focusable="false" viewBox="0 -833.9 4783 1083.9"
  xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.566ex;">
  <defs>
    <path id="MJX-2-TEX-N-63" d="M370 305T349 305T313 320T297 358Q297 381 312 396Q317 401 317 402T307 404Q281 408 258 408Q209 408 178 376Q131 329 131 219Q131 137 162 90Q203 29 272 29Q313 29 338 55T374 117Q376 125 379 127T395 129H409Q415 123 415 120Q415 116 411 104T395 71T366 33T318 2T249 -11Q163 -11 99 53T34 214Q34 318 99 383T250 448T370 421T404 357Q404 334 387 320Z"></path>
  </defs>
  <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)">
    <g data-mml-node="math">
      <g data-mml-node="mi" transform="translate(2198, 0)">
        <use xlink:href="#MJX-2-TEX-N-63"></use>
      </g>
    </g>
  </g>
</svg>
```