### PR TITLE
D2D port fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ svgnative/build/
 viewer/
 .vscode
 SVGNativeViewerLib.pc
+svgnative/out
+.vs

--- a/svgnative/example/testD2D/TestD2D.cpp
+++ b/svgnative/example/testD2D/TestD2D.cpp
@@ -22,180 +22,180 @@ governing permissions and limitations under the License.
 
 template <class T> void SafeRelease(T** ppT)
 {
-	if (*ppT)
-	{
-		(*ppT)->Release();
-		*ppT = nullptr;
-	}
+    if (*ppT)
+    {
+        (*ppT)->Release();
+        *ppT = nullptr;
+    }
 }
 
 namespace
 {
-	const std::string gSVGString = "<svg viewBox=\"0 0 200 200\"><rect width=\"20\" height=\"20\" fill=\"yellow\"/><g transform=\"translate(20, 20) scale(2)\" opacity=\"0.5\"><rect transform=\"rotate(15)\" width=\"20\" height=\"20\" fill=\"green\"/></g><rect x=\"60\" y=\"60\" width=\"140\" height=\"80\" rx=\"40\" ry=\"30\" fill=\"blue\"/><ellipse cx=\"140\" cy=\"100\" rx=\"40\" ry=\"20\" fill=\"purple\"/></svg>";
+    const std::string gSVGString = "<svg viewBox=\"0 0 200 200\"><rect width=\"20\" height=\"20\" fill=\"yellow\"/><g transform=\"translate(20, 20) scale(2)\" opacity=\"0.5\"><rect transform=\"rotate(15)\" width=\"20\" height=\"20\" fill=\"green\"/></g><rect x=\"60\" y=\"60\" width=\"140\" height=\"80\" rx=\"40\" ry=\"30\" fill=\"blue\"/><ellipse cx=\"140\" cy=\"100\" rx=\"40\" ry=\"20\" fill=\"purple\"/></svg>";
 }
 
 using namespace SVGNative;
 
 class MainWindow : public BaseWindow<MainWindow>
 {
-	ID2D1Factory* pFactory{};
-	ID2D1HwndRenderTarget* pRenderTarget{};
+    ID2D1Factory* pFactory{};
+    ID2D1HwndRenderTarget* pRenderTarget{};
 
-	std::shared_ptr<SVGNative::SVGDocument> pSVGDocument;
+    std::shared_ptr<SVGNative::SVGDocument> pSVGDocument;
 
-	void    CalculateLayout();
-	HRESULT CreateGraphicsResources();
-	void    DiscardGraphicsResources();
-	void    OnPaint();
-	void    Resize();
+    void    CalculateLayout();
+    HRESULT CreateGraphicsResources();
+    void    DiscardGraphicsResources();
+    void    OnPaint();
+    void    Resize();
 
 public:
 
-	MainWindow() = default;
+    MainWindow() = default;
 
-	PCWSTR  ClassName() const { return L"SVGRenderer Window Class"; }
-	LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    PCWSTR  ClassName() const { return L"SVGRenderer Window Class"; }
+    LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 // Recalculate drawing layout when the size of the window changes.
 
 void MainWindow::CalculateLayout()
 {
-	if (pRenderTarget)
-	{
-		// Layout changes (size) for the SVGRenderer are applied in OnPaint()
-	}
+    if (pRenderTarget)
+    {
+        // Layout changes (size) for the SVGRenderer are applied in OnPaint()
+    }
 }
 
 HRESULT MainWindow::CreateGraphicsResources()
 {
-	HRESULT hr = S_OK;
-	if (!pRenderTarget)
-	{
-		RECT rc;
-		GetClientRect(m_hwnd, &rc);
+    HRESULT hr = S_OK;
+    if (!pRenderTarget)
+    {
+        RECT rc;
+        GetClientRect(m_hwnd, &rc);
 
-		D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
+        D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
 
-		hr = pFactory->CreateHwndRenderTarget(
-			D2D1::RenderTargetProperties(),
-			D2D1::HwndRenderTargetProperties(m_hwnd, size),
-			&pRenderTarget);
+        hr = pFactory->CreateHwndRenderTarget(
+            D2D1::RenderTargetProperties(),
+            D2D1::HwndRenderTargetProperties(m_hwnd, size),
+            &pRenderTarget);
 
-		if (SUCCEEDED(hr))
-		{
-			if (pSVGDocument)
-			{
-				auto renderer = static_cast<D2DSVGRenderer*>(pSVGDocument->Renderer());
-				renderer->SetGraphicsContext(pWICFactory, pFactory, pRenderTarget);
-			}
-			else
-			{
-				auto renderer = std::shared_ptr<D2DSVGRenderer>(new D2DSVGRenderer);
-				renderer->SetGraphicsContext(pWICFactory, pFactory, pRenderTarget);
-				pSVGDocument = SVGDocument::CreateSVGDocument(gSVGString.c_str(), renderer);
-			}
+        if (SUCCEEDED(hr))
+        {
+            if (pSVGDocument)
+            {
+                auto renderer = static_cast<D2DSVGRenderer*>(pSVGDocument->Renderer());
+                renderer->SetGraphicsContext(pWICFactory, pFactory, pRenderTarget);
+            }
+            else
+            {
+                auto renderer = std::shared_ptr<D2DSVGRenderer>(new D2DSVGRenderer);
+                renderer->SetGraphicsContext(pWICFactory, pFactory, pRenderTarget);
+                pSVGDocument = SVGDocument::CreateSVGDocument(gSVGString.c_str(), renderer);
+            }
 
-			CalculateLayout();
-		}
-	}
-	return hr;
+            CalculateLayout();
+        }
+    }
+    return hr;
 }
 
 void MainWindow::DiscardGraphicsResources()
 {
-	SafeRelease(&pRenderTarget);
+    SafeRelease(&pRenderTarget);
 }
 
 void MainWindow::OnPaint()
 {
-	HRESULT hr = CreateGraphicsResources();
-	if (SUCCEEDED(hr))
-	{
-		PAINTSTRUCT ps;
-		BeginPaint(m_hwnd, &ps);
+    HRESULT hr = CreateGraphicsResources();
+    if (SUCCEEDED(hr))
+    {
+        PAINTSTRUCT ps;
+        BeginPaint(m_hwnd, &ps);
 
-		pRenderTarget->BeginDraw();
+        pRenderTarget->BeginDraw();
 
-		D2D1_SIZE_F size = pRenderTarget->GetSize();
-		pSVGDocument->Render(size.width, size.height);
+        D2D1_SIZE_F size = pRenderTarget->GetSize();
+        pSVGDocument->Render(size.width, size.height);
 
-		hr = pRenderTarget->EndDraw();
-		if (FAILED(hr) || hr == D2DERR_RECREATE_TARGET)
-		{
-			DiscardGraphicsResources();
-		}
-		EndPaint(m_hwnd, &ps);
-	}
+        hr = pRenderTarget->EndDraw();
+        if (FAILED(hr) || hr == D2DERR_RECREATE_TARGET)
+        {
+            DiscardGraphicsResources();
+        }
+        EndPaint(m_hwnd, &ps);
+    }
 }
 
 void MainWindow::Resize()
 {
-	if (pRenderTarget)
-	{
-		RECT rc;
-		GetClientRect(m_hwnd, &rc);
+    if (pRenderTarget)
+    {
+        RECT rc;
+        GetClientRect(m_hwnd, &rc);
 
-		D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
+        D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
 
-		pRenderTarget->Resize(size);
-		CalculateLayout();
-		InvalidateRect(m_hwnd, NULL, FALSE);
-	}
+        pRenderTarget->Resize(size);
+        CalculateLayout();
+        InvalidateRect(m_hwnd, NULL, FALSE);
+    }
 }
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int nCmdShow)
 {
-	MainWindow win;
+    MainWindow win;
 
-	if (!win.Create(L"D2DSVGRenderer", WS_OVERLAPPEDWINDOW))
-	{
-		return 0;
-	}
+    if (!win.Create(L"D2DSVGRenderer", WS_OVERLAPPEDWINDOW))
+    {
+        return 0;
+    }
 
-	ShowWindow(win.Window(), nCmdShow);
+    ShowWindow(win.Window(), nCmdShow);
 
-	// Run the message loop.
+    // Run the message loop.
 
-	MSG msg = { };
-	while (GetMessage(&msg, NULL, 0, 0))
-	{
-		TranslateMessage(&msg);
-		DispatchMessage(&msg);
-	}
+    MSG msg = { };
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
 
-	return 0;
+    return 0;
 }
 
 LRESULT MainWindow::HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-	case WM_CREATE:
-		{
-			constexpr D2D1_FACTORY_OPTIONS factoryOptions{ D2D1_DEBUG_LEVEL_NONE };
+    switch (uMsg)
+    {
+    case WM_CREATE:
+        {
+            constexpr D2D1_FACTORY_OPTIONS factoryOptions{ D2D1_DEBUG_LEVEL_NONE };
 			if (FAILED(D2D1CreateFactory(
 				D2D1_FACTORY_TYPE_SINGLE_THREADED, factoryOptions, &pFactory)))
-			{
+            {
 				return -1;  // Fail CreateWindowEx.
-			}
+            }
 			return 0;
-		}
-	case WM_DESTROY:
-		DiscardGraphicsResources();
-		SafeRelease(&pFactory);
-		PostQuitMessage(0);
-		return 0;
+        }
+    case WM_DESTROY:
+        DiscardGraphicsResources();
+        SafeRelease(&pFactory);
+        PostQuitMessage(0);
+        return 0;
 
-	case WM_PAINT:
-		OnPaint();
-		return 0;
+    case WM_PAINT:
+        OnPaint();
+        return 0;
 
-		// Other messages not shown...
+        // Other messages not shown...
 
-	case WM_SIZE:
-		Resize();
-		return 0;
-	}
-	return DefWindowProc(m_hwnd, uMsg, wParam, lParam);
+    case WM_SIZE:
+        Resize();
+        return 0;
+    }
+    return DefWindowProc(m_hwnd, uMsg, wParam, lParam);
 }

--- a/svgnative/example/testD2D/TestD2D.cpp
+++ b/svgnative/example/testD2D/TestD2D.cpp
@@ -12,116 +12,197 @@ governing permissions and limitations under the License.
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <tchar.h>
 #include <windows.h>
-#include <unknwn.h>
-#include <D2d1.h>
-#include <memory>
+#include <d2d1.h>
+#pragma comment(lib, "d2d1")
 
+#include "basewin.h"
 #include "svgnative/SVGDocument.h"
 #include "svgnative/ports/d2d/D2DSVGRenderer.h"
 
-/* We need to include the Gdiplus lib */
-#pragma comment (lib, "D2d1.lib")
+template <class T> void SafeRelease(T** ppT)
+{
+	if (*ppT)
+	{
+		(*ppT)->Release();
+		*ppT = NULL;
+	}
+}
 
-using namespace D2D1;
+namespace
+{
+	const std::string gSVGString = "<svg viewBox=\"0 0 200 200\"><rect width=\"20\" height=\"20\" fill=\"yellow\"/><g transform=\"translate(20, 20) scale(2)\" opacity=\"0.5\"><rect transform=\"rotate(15)\" width=\"20\" height=\"20\" fill=\"green\"/></g><rect x=\"60\" y=\"60\" width=\"140\" height=\"80\" rx=\"40\" ry=\"30\" fill=\"blue\"/><ellipse cx=\"140\" cy=\"100\" rx=\"40\" ry=\"20\" fill=\"purple\"/></svg>";
+}
+
 using namespace SVGNative;
 
-static HWND hwndMain = NULL;
-
-static const std::string gSVGString = "<svg viewBox=\"0 0 200 200\"><rect width=\"20\" height=\"20\" fill=\"yellow\"/><g transform=\"translate(20, 20) scale(2)\" opacity=\"0.5\"><rect transform=\"rotate(15)\" width=\"20\" height=\"20\" fill=\"green\"/></g><rect x=\"60\" y=\"60\" width=\"140\" height=\"80\" rx=\"40\" ry=\"30\" fill=\"blue\"/><ellipse cx=\"140\" cy=\"100\" rx=\"40\" ry=\"20\" fill=\"purple\"/></svg>";
-
-static void
-MainWinPaintToCanvas(HWND hwnd)
+class MainWindow : public BaseWindow<MainWindow>
 {
-    // Init D2D and create factory
-    constexpr D2D1_FACTORY_OPTIONS factoryOptions{ D2D1_DEBUG_LEVEL_NONE };
+	ID2D1Factory* pFactory;
+	ID2D1HwndRenderTarget* pRenderTarget;
+	ID2D1SolidColorBrush* pBrush;
+	D2D1_ELLIPSE            ellipse;
 
-    ID2D1Factory* pD2DFactory{};
-    D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &pD2DFactory);
+	void    CalculateLayout();
+	HRESULT CreateGraphicsResources();
+	void    DiscardGraphicsResources();
+	void    OnPaint();
+	void    Resize();
 
-    // Init render target
-    RECT rc;
-    GetClientRect(hwnd, &rc);
+public:
 
-    D2D1_SIZE_U size = D2D1::SizeU(
-        rc.right - rc.left,
-        rc.bottom - rc.top);
+	MainWindow() : pFactory(NULL), pRenderTarget(NULL), pBrush(NULL)
+	{
+	}
 
-    // Create a Direct2D render target.
-    ID2D1HwndRenderTarget* pD2DenderTarget{};
-    pD2DFactory->CreateHwndRenderTarget(
-        D2D1::RenderTargetProperties(),
-        D2D1::HwndRenderTargetProperties(hwnd, size),
-        &pD2DenderTarget);
+	PCWSTR  ClassName() const { return L"SVGRenderer Window Class"; }
+	LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+};
 
-    pD2DenderTarget->BeginDraw();
+// Recalculate drawing layout when the size of the window changes.
 
-    auto renderer = std::shared_ptr<D2DSVGRenderer>(new D2DSVGRenderer);
-    renderer->SetGraphicsContext(pD2DFactory, pD2DenderTarget);
-
-    auto svgDocument = SVGDocument::CreateSVGDocument(gSVGString.c_str(), renderer);
-    svgDocument->Render();
-
-    pD2DenderTarget->EndDraw();
+void MainWindow::CalculateLayout()
+{
+	if (pRenderTarget != NULL)
+	{
+		D2D1_SIZE_F size = pRenderTarget->GetSize();
+		const float x = size.width / 2;
+		const float y = size.height / 2;
+		const float radius = min(x, y);
+		ellipse = D2D1::Ellipse(D2D1::Point2F(x, y), radius, radius);
+	}
 }
 
-/* Main window procedure */
-static LRESULT CALLBACK
-MainWinProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+HRESULT MainWindow::CreateGraphicsResources()
 {
-    switch(uMsg) {
-        case WM_PAINT:
-        {
-            MainWinPaintToCanvas(hwnd);
-            return 0;
-        }
+	HRESULT hr = S_OK;
+	if (pRenderTarget == NULL)
+	{
+		RECT rc;
+		GetClientRect(m_hwnd, &rc);
 
-        case WM_PRINTCLIENT:
-            PostQuitMessage(0);
-            return 0;
+		D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
 
-        case WM_DESTROY:
-            PostQuitMessage(0);
-            return 0;
-    }
+		hr = pFactory->CreateHwndRenderTarget(
+			D2D1::RenderTargetProperties(),
+			D2D1::HwndRenderTargetProperties(m_hwnd, size),
+			&pRenderTarget);
 
-    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+		if (SUCCEEDED(hr))
+		{
+			const D2D1_COLOR_F color = D2D1::ColorF(1.0f, 1.0f, 0);
+			hr = pRenderTarget->CreateSolidColorBrush(color, &pBrush);
+
+			if (SUCCEEDED(hr))
+			{
+				CalculateLayout();
+			}
+		}
+	}
+	return hr;
 }
 
-int APIENTRY
-_tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmdShow)
+void MainWindow::DiscardGraphicsResources()
 {
-    WNDCLASS wc = { 0 };
-    MSG msg;
+	SafeRelease(&pRenderTarget);
+	SafeRelease(&pBrush);
+}
 
-    /* Register main window class */
-    wc.lpfnWndProc = MainWinProc;
-    wc.hInstance = hInstance;
-    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
-    wc.lpszClassName = _T("main_window");
-    RegisterClass(&wc);
+void MainWindow::OnPaint()
+{
+	HRESULT hr = CreateGraphicsResources();
+	if (SUCCEEDED(hr))
+	{
+		PAINTSTRUCT ps;
+		BeginPaint(m_hwnd, &ps);
 
-    /* Create main window */
-    hwndMain = CreateWindow(
-        _T("main_window"), _T("LibWinDraw Example: Simple Draw"),
-        WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 550, 350,
-        NULL, NULL, hInstance, NULL
-    );
-    SendMessage(hwndMain, WM_SETFONT, (WPARAM) GetStockObject(DEFAULT_GUI_FONT),
-            MAKELPARAM(TRUE, 0));
-    ShowWindow(hwndMain, nCmdShow);
+		pRenderTarget->BeginDraw();
 
-    /* Message loop */
-    while(GetMessage(&msg, NULL, 0, 0)) {
-        if(IsDialogMessage(hwndMain, &msg))
-            continue;
+		auto renderer = std::shared_ptr<D2DSVGRenderer>(new D2DSVGRenderer);
+		renderer->SetGraphicsContext(pFactory, pRenderTarget);
 
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
+		auto svgDocument = SVGDocument::CreateSVGDocument(gSVGString.c_str(), renderer);
+		if (svgDocument)
+		{
+			svgDocument->Render();
+		}
 
-    /* Return exit code of WM_QUIT */
-    return (int)msg.wParam;
+		hr = pRenderTarget->EndDraw();
+		if (FAILED(hr) || hr == D2DERR_RECREATE_TARGET)
+		{
+			DiscardGraphicsResources();
+		}
+		EndPaint(m_hwnd, &ps);
+	}
+}
+
+void MainWindow::Resize()
+{
+	if (pRenderTarget != NULL)
+	{
+		RECT rc;
+		GetClientRect(m_hwnd, &rc);
+
+		D2D1_SIZE_U size = D2D1::SizeU(rc.right, rc.bottom);
+
+		pRenderTarget->Resize(size);
+		CalculateLayout();
+		InvalidateRect(m_hwnd, NULL, FALSE);
+	}
+}
+
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int nCmdShow)
+{
+	MainWindow win;
+
+	if (!win.Create(L"D2DSVGRenderer", WS_OVERLAPPEDWINDOW))
+	{
+		return 0;
+	}
+
+	ShowWindow(win.Window(), nCmdShow);
+
+	// Run the message loop.
+
+	MSG msg = { };
+	while (GetMessage(&msg, NULL, 0, 0))
+	{
+		TranslateMessage(&msg);
+		DispatchMessage(&msg);
+	}
+
+	return 0;
+}
+
+LRESULT MainWindow::HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	switch (uMsg)
+	{
+	case WM_CREATE:
+		{
+			constexpr D2D1_FACTORY_OPTIONS factoryOptions{ D2D1_DEBUG_LEVEL_NONE };
+			if (FAILED(D2D1CreateFactory(
+				D2D1_FACTORY_TYPE_SINGLE_THREADED, factoryOptions, &pFactory)))
+			{
+				return -1;  // Fail CreateWindowEx.
+			}
+			return 0;
+		}
+	case WM_DESTROY:
+		DiscardGraphicsResources();
+		SafeRelease(&pFactory);
+		PostQuitMessage(0);
+		return 0;
+
+	case WM_PAINT:
+		OnPaint();
+		return 0;
+
+		// Other messages not shown...
+
+	case WM_SIZE:
+		Resize();
+		return 0;
+	}
+	return DefWindowProc(m_hwnd, uMsg, wParam, lParam);
 }

--- a/svgnative/example/testD2D/TestD2D.cpp
+++ b/svgnative/example/testD2D/TestD2D.cpp
@@ -31,7 +31,7 @@ template <class T> void SafeRelease(T** ppT)
 
 namespace
 {
-    const std::string gSVGString = "<svg viewBox=\"0 0 200 200\"><rect width=\"20\" height=\"20\" fill=\"yellow\"/><g transform=\"translate(20, 20) scale(2)\" opacity=\"0.5\"><rect transform=\"rotate(15)\" width=\"20\" height=\"20\" fill=\"green\"/></g><rect x=\"60\" y=\"60\" width=\"140\" height=\"80\" rx=\"40\" ry=\"30\" fill=\"blue\"/><ellipse cx=\"140\" cy=\"100\" rx=\"40\" ry=\"20\" fill=\"purple\"/></svg>";
+    const std::string gSVGString = R"SVG(<svg viewBox="0 0 200 200"><rect width="20" height="20" fill="yellow"/><g transform="translate(20, 20) scale(2)" opacity="0.5"><rect transform="rotate(15)" width="20" height="20" fill="green"/></g><rect x="60" y="60" width="140" height="80" rx="40" ry="30" fill="blue"/><ellipse cx="140" cy="100" rx="40" ry="20" fill="purple"/></svg>)SVG";
 }
 
 using namespace SVGNative;

--- a/svgnative/example/testD2D/basewin.h
+++ b/svgnative/example/testD2D/basewin.h
@@ -1,0 +1,71 @@
+#pragma once
+
+template <class DERIVED_TYPE>
+class BaseWindow
+{
+public:
+    static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+    {
+        DERIVED_TYPE* pThis = NULL;
+
+        if (uMsg == WM_NCCREATE)
+        {
+            CREATESTRUCT* pCreate = (CREATESTRUCT*)lParam;
+            pThis = (DERIVED_TYPE*)pCreate->lpCreateParams;
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)pThis);
+
+            pThis->m_hwnd = hwnd;
+        }
+        else
+        {
+            pThis = (DERIVED_TYPE*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+        }
+        if (pThis)
+        {
+            return pThis->HandleMessage(uMsg, wParam, lParam);
+        }
+        else
+        {
+            return DefWindowProc(hwnd, uMsg, wParam, lParam);
+        }
+    }
+
+    BaseWindow() : m_hwnd(NULL) { }
+
+    BOOL Create(
+        PCWSTR lpWindowName,
+        DWORD dwStyle,
+        DWORD dwExStyle = 0,
+        int x = CW_USEDEFAULT,
+        int y = CW_USEDEFAULT,
+        int nWidth = CW_USEDEFAULT,
+        int nHeight = CW_USEDEFAULT,
+        HWND hWndParent = 0,
+        HMENU hMenu = 0
+    )
+    {
+        WNDCLASS wc = { 0 };
+
+        wc.lpfnWndProc = DERIVED_TYPE::WindowProc;
+        wc.hInstance = GetModuleHandle(NULL);
+        wc.lpszClassName = ClassName();
+
+        RegisterClass(&wc);
+
+        m_hwnd = CreateWindowEx(
+            dwExStyle, ClassName(), lpWindowName, dwStyle, x, y,
+            nWidth, nHeight, hWndParent, hMenu, GetModuleHandle(NULL), this
+        );
+
+        return (m_hwnd ? TRUE : FALSE);
+    }
+
+    HWND Window() const { return m_hwnd; }
+
+protected:
+
+    virtual PCWSTR  ClassName() const = 0;
+    virtual LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) = 0;
+
+    HWND m_hwnd;
+};

--- a/svgnative/include/svgnative/ports/d2d/D2DSVGRenderer.h
+++ b/svgnative/include/svgnative/ports/d2d/D2DSVGRenderer.h
@@ -14,15 +14,16 @@ governing permissions and limitations under the License.
 #define SVGViewer_D2DSVGRenderer_h
 
 #include "svgnative/SVGRenderer.h"
-#include <D2d1.h>
+#include <d2d1.h>
 #include <stack>
+#include <atlbase.h> // CComPtr
 
 namespace SVGNative
 {
 class D2DSVGPath final : public Path
 {
 public:
-    D2DSVGPath(ID2D1Factory*);
+    D2DSVGPath(CComPtr<ID2D1Factory>);
     ~D2DSVGPath();
 
     void Rect(float x, float y, float width, float height) override;
@@ -35,15 +36,15 @@ public:
     void CurveToV(float x2, float y2, float x3, float y3) override;
     void ClosePath() override;
 
-    ID2D1PathGeometry* GetGraphicsPath();
+    CComPtr<ID2D1PathGeometry> GetGraphicsPath();
 
 private:
     void AddArc(float x, float y, float dx, float dy);
     void ClosePathSink();
 
 private:
-    ID2D1PathGeometry* mPath{};
-    ID2D1GeometrySink* mSink{};
+    CComPtr<ID2D1PathGeometry> mPath;
+    CComPtr<ID2D1GeometrySink> mSink;
     bool mHasOpenFigure{ false };
     float mCurrentX{};
     float mCurrentY{};
@@ -81,7 +82,7 @@ class SVG_IMP_EXP D2DSVGRenderer final : public SVGRenderer
 public:
     D2DSVGRenderer();
 
-    virtual ~D2DSVGRenderer() 
+    virtual ~D2DSVGRenderer()
     { 
     }
 
@@ -100,20 +101,20 @@ public:
 
     void SetGraphicsContext(ID2D1Factory* inPDirect2dFactory, ID2D1RenderTarget* renderTarget)
     {
-        mPDirect2dFactory = inPDirect2dFactory;
+        mD2DFactory = inPDirect2dFactory;
         mContext = renderTarget;
     }
 
     void ReleaseGraphicsContext()
     {
-        mPDirect2dFactory = nullptr;
+        mD2DFactory.Release();
     }
 
 private:
-    ID2D1Brush* D2DSVGRenderer::CreateBrush(const Paint& paint);
+    CComPtr<ID2D1Brush> D2DSVGRenderer::CreateBrush(const Paint& paint);
 
-    ID2D1RenderTarget* mContext{};
-    ID2D1Factory* mPDirect2dFactory{};
+    CComPtr<ID2D1RenderTarget> mContext;
+    CComPtr<ID2D1Factory> mD2DFactory;
 
     std::stack<D2D1_MATRIX_3X2_F> mContextTransform;
 };

--- a/svgnative/src/ports/d2d/D2DSVGRenderer.cpp
+++ b/svgnative/src/ports/d2d/D2DSVGRenderer.cpp
@@ -416,7 +416,7 @@ void D2DSVGRenderer::DrawPath(const Path& renderPath, const GraphicStyle& graphi
 
     Save(graphicStyle);
 
-    const auto constPath = dynamic_cast<const D2DSVGPath&>(renderPath);
+    const auto& constPath = dynamic_cast<const D2DSVGPath&>(renderPath);
     auto path = const_cast<D2DSVGPath&>(constPath).GetGraphicsPath();
     if (fillStyle.hasFill)
     {


### PR DESCRIPTION
Fix the over-release issue with a ID2D1PathGeometry object and update the test app from a D2D test sample source.

The over-release issue can be fixed by avoiding a copy of an D2DSVGPath but to make D2D objects generally copyable and handle lifetime issues all D2D objects are now wrapped by a smart pointer (CComPtr). The only downside here is that CComPtr is part of Windows' Active Template Library (ATL) which might not be available everywhere.
