### PR TITLE
Fix transform concatenation problem

### DIFF
--- a/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
+++ b/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
@@ -160,7 +160,7 @@ void CairoSVGTransform::Scale(float sx, float sy)
 void CairoSVGTransform::Concat(float a, float b, float c, float d, float tx, float ty)
 {
     cairo_matrix_t other{a, b, c, d, tx, ty};
-    cairo_matrix_multiply(&mMatrix, &mMatrix, &other);
+    cairo_matrix_multiply(&mMatrix, &other, &mMatrix);
 }
 
 CairoSVGImageData::CairoSVGImageData(const std::string& base64, ImageEncoding encoding)

--- a/svgnative/src/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/src/ports/cg/CGSVGRenderer.cpp
@@ -78,7 +78,7 @@ void CGSVGTransform::Scale(float sx, float sy) { mTransform = CGAffineTransformS
 
 void CGSVGTransform::Concat(float a, float b, float c, float d, float tx, float ty)
 {
-    mTransform = CGAffineTransformConcat(mTransform, {a, b, c, d, tx, ty});
+    mTransform = CGAffineTransformConcat({a, b, c, d, tx, ty}, mTransform);
 }
 
 CGSVGImageData::CGSVGImageData(const std::string& base64, ImageEncoding encoding)


### PR DESCRIPTION
This should solve #137.

There is inconsistency in the way concatenation is handled across the four ports and that's what leads to this behavior. You can also observe the same behavior by having a node with a `transform` attribute that has a `matrix` transform following other transforms such as `translate` or `scale` or `rotate`.

This PR should be reviewed with a lot of care as I'm not fully sure if my analysis is correct, but I present it here for you to review it.

I think the way SNV expects the `Transform` interface to work is such that each new transformation is supposed to happen before everything that came before it. For example, take a look at the following three calls:

```
matrix.Translate(500, 500); // 3
matrix.Rotate(45); // 2
matrix.Translate(-500, -500); // 1
```

The shape that'll be transformed by the resultant matrix should transform in the order 1, 2, 3 and NOT 3, 2, 1.

Given this assumption, we can look at how to make sure this is the case across all the four ports.

### Cairo
[This](https://www.cairographics.org/manual/cairo-cairo-matrix-t.html) describes how a point is transformed by Cairo's CTM and also shows the documentation for `cairo_matrix_multiply`. The documentation says the the combined effect is that `a` is applied first on the point and `b` is applied later. If that's the case, in our `Concat` function, the new matrix should be `a` and the old matrix should be `b`. That's not the case right now, so we flip to make that happen.

### Skia
[This](https://api.skia.org/classSkMatrix.html) shows how the matrix is multiplied with a point to transform it and it's almost identical to Cairo. Let's say that the current matrix is `a` and the point to apply it on is `p`, the result is given by `a*p`. When a new matrix is to be concatenated, we would want it to be multiplied as `a*new*p`. Which is exactly what `preConcat` does. That's what the current code does so we are good.

### CG
[This](https://developer.apple.com/documentation/coregraphics/cgaffinetransform?language=objc) shows how a point is transformed by the CTM in CG. As we can see, the mathematics is different than Skia and Cairo. Here the point is a row vector that precedes the matrix. If the current matrix is `a` and the point is `p`, the transformation is `p*a`. Any new transformation should be multiplied as `p*b*a` which is not what happens currently. So we flip to make that happen.

### GDIPLUS
[This](https://docs.microsoft.com/en-us/windows/win32/api/gdiplusmatrix/nf-gdiplusmatrix-matrix-transformpoints(point_int)) and [this](https://docs.microsoft.com/en-us/windows/win32/api/gdiplusmatrix/nl-gdiplusmatrix-matrix) show that the matrix is a 3x3 and the behavior is similar to CoreGraphics. Thus, a new matrix would need to be pre-multiplied with the old one. The function `::Multiply` already does that as shown [here](https://docs.microsoft.com/en-us/windows/win32/api/gdiplusmatrix/nf-gdiplusmatrix-matrix-multiply). The order is `Prepend` by default.

I hope this analysis clears up the issue and helps the reviewers.