### PR TITLE
Fix Quadratic Beziers problem

### DIFF
--- a/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
+++ b/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
@@ -122,10 +122,10 @@ void CairoSVGPath::CurveTo(float x1, float y1, float x2, float y2, float x3, flo
 
 void CairoSVGPath::CurveToV(float x2, float y2, float x3, float y3)
 {
-    float cx1 = static_cast<float>(mCurrentX + 2.0 / 3.0 * (x2 - mCurrentX));
-    float cy1 = static_cast<float>(mCurrentY + 2.0 / 3.0 * (y2 - mCurrentY));
-    float cx2 = static_cast<float>(x3 + 2.0 / 3.0 * (x2 - x3));
-    float cy2 = static_cast<float>(y3 + 2.0 / 3.0 * (y2 - y3));
+    float cx1 = mCurrentX + 2.0f / 3.0f * (x2 - mCurrentX);
+    float cy1 = mCurrentY + 2.0f / 3.0f * (y2 - mCurrentY);
+    float cx2 = x3 + 2.0f / 3.0f * (x2 - x3);
+    float cy2 = y3 + 2.0f / 3.0f * (y2 - y3);
 
     cairo_curve_to(mPathCtx, cx1, cy1, cx2, cy2, x3, y3);
     mCurrentX = x3;

--- a/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
+++ b/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
@@ -127,7 +127,7 @@ void CairoSVGPath::CurveToV(float x2, float y2, float x3, float y3)
     float cx2 = static_cast<float>(x3 + 2.0 / 3.0 * (x2 - x3));
     float cy2 = static_cast<float>(y3 + 2.0 / 3.0 * (y2 - y3));
 
-    cairo_curve_to(mPathCtx, x1, y1, x2, y2, x3, y3);
+    cairo_curve_to(mPathCtx, cx1, cy1, cx2, cy2, x3, y3);
     mCurrentX = x3;
     mCurrentY = y3;
 }

--- a/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
+++ b/svgnative/src/ports/cairo/CairoSVGRenderer.cpp
@@ -122,7 +122,12 @@ void CairoSVGPath::CurveTo(float x1, float y1, float x2, float y2, float x3, flo
 
 void CairoSVGPath::CurveToV(float x2, float y2, float x3, float y3)
 {
-    cairo_curve_to(mPathCtx, mCurrentX, mCurrentY, x2, y2, x3, y3);
+    float cx1 = static_cast<float>(mCurrentX + 2.0 / 3.0 * (x2 - mCurrentX));
+    float cy1 = static_cast<float>(mCurrentY + 2.0 / 3.0 * (y2 - mCurrentY));
+    float cx2 = static_cast<float>(x3 + 2.0 / 3.0 * (x2 - x3));
+    float cy2 = static_cast<float>(y3 + 2.0 / 3.0 * (y2 - y3));
+
+    cairo_curve_to(mPathCtx, x1, y1, x2, y2, x3, y3);
     mCurrentX = x3;
     mCurrentY = y3;
 }

--- a/svgnative/src/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/src/ports/cg/CGSVGRenderer.cpp
@@ -57,7 +57,7 @@ void CGSVGPath::CurveTo(float x1, float y1, float x2, float y2, float x3, float 
 
 void CGSVGPath::CurveToV(float x2, float y2, float x3, float y3)
 {
-    CGPathAddCurveToPoint(mPath, nullptr, mCurrentX, mCurrentY, x2, y2, x3, y3);
+    CGPathAddQuadCurveToPoint(mPath, nullptr, x2, y2, x3, y3);
     mCurrentX = x3;
     mCurrentY = y3;
 }

--- a/svgnative/src/ports/gdiplus/GDIPlusSVGRenderer.cpp
+++ b/svgnative/src/ports/gdiplus/GDIPlusSVGRenderer.cpp
@@ -89,10 +89,10 @@ void GDIPlusSVGPath::CurveTo(float x1, float y1, float x2, float y2, float x3, f
 
 void GDIPlusSVGPath::CurveToV(float x2, float y2, float x3, float y3)
 {
-    float cx1 = static_cast<float>(mCurrentX + 2.0 / 3.0 * (x2 - mCurrentX));
-    float cy1 = static_cast<float>(mCurrentY + 2.0 / 3.0 * (y2 - mCurrentY));
-    float cx2 = static_cast<float>(x3 + 2.0 / 3.0 * (x2 - x3));
-    float cy2 = static_cast<float>(y3 + 2.0 / 3.0 * (y2 - y3));
+    float cx1 = mCurrentX + 2.0f / 3.0f * (x2 - mCurrentX);
+    float cy1 = mCurrentY + 2.0f / 3.0f * (y2 - mCurrentY);
+    float cx2 = x3 + 2.0f / 3.0f * (x2 - x3);
+    float cy2 = y3 + 2.0f / 3.0f * (y2 - y3);
 
     mPath.AddBezier(mCurrentX, mCurrentY, cx1, cy1, cx2, cy2, x3, y3);
     mCurrentX = x3;

--- a/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
@@ -67,7 +67,7 @@ void SkiaSVGPath::CurveTo(float x1, float y1, float x2, float y2, float x3, floa
 
 void SkiaSVGPath::CurveToV(float x2, float y2, float x3, float y3)
 {
-    mPath.cubicTo(mCurrentX, mCurrentY, x2, y2, x3, y3);
+    mPath.quadTo(x2, y2, x3, y3);
     mCurrentX = x3;
     mCurrentY = y3;
 }


### PR DESCRIPTION
This should fix #151. Surprisingly, the GDI+ port already had the necessary conversion code while Cairo didn't. Skia and CG both have API calls for Quadratic Curves and yet they were not being used.