### PR TITLE
Resolution for issue Fill or stroke attributes on a use element 

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -321,7 +321,6 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
         auto hrefAttr = child->GetAttribute(kHrefAttr, kXlinkNS);
         if (!hrefAttr.found || !hrefAttr.value || hrefAttr.value[0] != '#')
             return;
-
         const float x = ParseLengthFromAttr(child, kXAttr, LengthType::kHorizontal);
         const float y = ParseLengthFromAttr(child, kYAttr, LengthType::kVertical);
         if (!isCloseToZero(x) || !isCloseToZero(y))
@@ -330,7 +329,6 @@ void SVGDocumentImpl::ParseChild(XMLNode* child)
                 graphicStyle.transform = mRenderer->CreateTransform();
             graphicStyle.transform->Concat(1, 0, 0, 1, x, y);
         }
-
         std::string href{(hrefAttr.value + 1)};
         AddChildToCurrentGroup(std::make_shared<Reference>(graphicStyle, classNames, fillStyle, strokeStyle, std::move(href)), std::move(idString));
     }
@@ -606,7 +604,6 @@ void SVGDocumentImpl::ParseFillProperties(FillStyleImpl& fillStyle, const Proper
         else if (result == SVGDocumentImpl::Result::kSuccess)
             fillStyle.hasFill = true;
     }
-
     prop = propertySet.find(kFillOpacityProp);
     if (prop != iterEnd)
     {
@@ -820,7 +817,6 @@ float SVGDocumentImpl::ParseColorStop(const XMLNode* node, std::vector<ColorStop
         // Value is "currentColor". Simply set value to CSS color property.
         paint = fillStyle.color;
     }
-
     graphicStyle.stopOpacity = std::max<float>(0.0, std::min<float>(1.0, graphicStyle.stopOpacity));
 
     colorStops.push_back(std::make_tuple(offset, paint, graphicStyle.stopOpacity));
@@ -1063,13 +1059,18 @@ void SVGDocumentImpl::TraverseTree(const ColorMap& colorMap, const Element& elem
         if (it != mVisitedElements.end())
             break; // We found a cycle. Do not continue rendering.
         auto insertResult = mVisitedElements.insert(&reference);
-
         // Render referenced content.
         auto refIt = mIdToElementMap.find(reference.href);
         if (refIt != mIdToElementMap.end())
         {
             ApplyCSSStyle(reference.classNames, graphicStyle, fillStyle, strokeStyle);
             auto saveRestore = SaveRestoreHelper{mRenderer, reference.graphicStyle};
+            if ((*(refIt->second)).Type() == ElementType::kGraphic)
+            {
+                Graphic& graphic = static_cast<Graphic&>(*(refIt->second));
+                // it will call assignment operator and pass fillStyle from reference to graphic
+                graphic = reference;
+            }
             TraverseTree(colorMap, *(refIt->second));
         }
 
@@ -1115,7 +1116,7 @@ void SVGDocumentImpl::TraverseTree(const ColorMap& colorMap, const Element& elem
     }
 }
 
-#ifndef STYLE_SUPPORT
+#ifndef STYLE_SUPPORTn
 // Deprecated style support
 void SVGDocumentImpl::ApplyCSSStyle(
     const std::set<std::string>&, GraphicStyleImpl&, FillStyleImpl&, StrokeStyleImpl&) {}

--- a/svgnative/src/SVGDocumentImpl.h
+++ b/svgnative/src/SVGDocumentImpl.h
@@ -133,24 +133,6 @@ public:
         ElementType Type() const override { return ElementType::kGroup; }
     };
 
-    struct Graphic : public Element
-    {
-        Graphic(GraphicStyleImpl& aGraphicStyle, std::set<std::string>& aClasses, FillStyleImpl& aFillStyle, StrokeStyleImpl& aStrokeStyle,
-            std::shared_ptr<Path> aPath)
-            : Element(aGraphicStyle, aClasses)
-            , fillStyle{aFillStyle}
-            , strokeStyle{aStrokeStyle}
-            , path{std::move(aPath)}
-        {
-        }
-
-        FillStyleImpl fillStyle;
-        StrokeStyleImpl strokeStyle;
-        std::shared_ptr<Path> path;
-
-        ElementType Type() const override { return ElementType::kGraphic; }
-    };
-
     struct Reference : public Element
     {
         Reference(GraphicStyleImpl& aGraphicStyle, std::set<std::string>& aClasses, FillStyleImpl& aFillStyle, StrokeStyleImpl& aStrokeStyle,
@@ -167,6 +149,30 @@ public:
         std::string href;
 
         ElementType Type() const override { return ElementType::kReference; }
+    };
+    
+    struct Graphic : public Element
+    {
+        Graphic(GraphicStyleImpl& aGraphicStyle, std::set<std::string>& aClasses, FillStyleImpl& aFillStyle, StrokeStyleImpl& aStrokeStyle,
+            std::shared_ptr<Path> aPath)
+            : Element(aGraphicStyle, aClasses)
+            , fillStyle{aFillStyle}
+            , strokeStyle{aStrokeStyle}
+            , path{std::move(aPath)}
+        {
+        }
+
+        FillStyleImpl fillStyle;
+        StrokeStyleImpl strokeStyle;
+        std::shared_ptr<Path> path;
+
+        ElementType Type() const override { return ElementType::kGraphic; }
+        Graphic& operator= (const Reference& refObj)
+        {
+            this->fillStyle = refObj.fillStyle; //internal Paint is transferred
+            this->strokeStyle = refObj.strokeStyle;
+            return *this;
+        }
     };
 
     SVGDocumentImpl(std::shared_ptr<SVGRenderer> renderer);

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -1132,6 +1132,7 @@ SVGDocumentImpl::Result ParsePaint(const std::string& colorString, const std::ma
     {
         if (urlResult == SVGDocumentImpl::Result::kInvalid && result != SVGDocumentImpl::Result::kInvalid)
             paint = altPaint;
+        
         return result;
     }
 


### PR DESCRIPTION
Resolution for issue Fill or stroke attributes on a use element changes as paint implementation is not getting transfered from reference to graphic element

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
