### PR TITLE
Include <string> in ExpatXMLParser.cpp

### DIFF
--- a/svgnative/src/xml/ExpatXMLParser.cpp
+++ b/svgnative/src/xml/ExpatXMLParser.cpp
@@ -16,6 +16,7 @@ governing permissions and limitations under the License.
 #include <expat.h>
 #include <map>
 #include <stack>
+#include <string>
 #include <string.h>
 
 namespace SVGNative


### PR DESCRIPTION
Both `<string>` and `<string.h>` are needed in ExpatXMLParser.cpp.
