### PR TITLE
Explicitly define ~SkiaSVGImageData

### DIFF
--- a/svgnative/include/svgnative/ports/skia/SkiaSVGRenderer.h
+++ b/svgnative/include/svgnative/ports/skia/SkiaSVGRenderer.h
@@ -62,6 +62,7 @@ class SkiaSVGImageData final : public ImageData
 {
 public:
     SkiaSVGImageData(const std::string& base64, ImageEncoding encoding);
+    ~SkiaSVGImageData() override;
 
     float Width() const override;
 

--- a/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
@@ -155,6 +155,10 @@ SkiaSVGImageData::SkiaSVGImageData(const std::string& base64, ImageEncoding /*en
     }
 }
 
+SkiaSVGImageData::~SkiaSVGImageData()
+{
+}
+
 float SkiaSVGImageData::Width() const
 {
     if (!mImageData)


### PR DESCRIPTION
The `SkiaSVGImageData` destructor must destroy an `sk_sp<SkImage>` member.
However, `SkiaSVGRenderer.h` only has a forward declaration of `SkImage` so
the default inline destructor cannot destruct the `SkImage` unless the
translation unit which includes `SkiaSVGRenderer.h` pulls in the full
definition of `SkImage`. Remove this awkward situation by defining the
destructor in `SkiaSVGRenderer.cpp`, which does have a full definition of
`SkImage`.