### PR TITLE
Include SkEncodedImageFormat.h in TestSkia.cpp.

### DIFF
--- a/svgnative/example/testSkia/TestSkia.cpp
+++ b/svgnative/example/testSkia/TestSkia.cpp
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 #include "svgnative/SVGDocument.h"
 #include "SkData.h"
+#include "SkEncodedImageFormat.h"
 #include "SkImage.h"
 #include "SkStream.h"
 #include "SkSurface.h"


### PR DESCRIPTION
Some IWYU to allow TestSkia.cpp to build with newer versions of Skia
where SkEncodedImageFormat is not implicitly included through other
includes.