### PR TITLE
Check SkCodec was created before getting origin.

### DIFF
--- a/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
+++ b/svgnative/src/ports/skia/SkiaSVGRenderer.cpp
@@ -145,7 +145,10 @@ SkiaSVGImageData::SkiaSVGImageData(const std::string& base64, ImageEncoding /*en
 {
     std::string imageString = base64_decode(base64);
     auto skData = SkData::MakeWithCopy(imageString.data(), imageString.size());
-    SkEncodedOrigin origin = SkCodec::MakeFromData(skData, nullptr)->getOrigin();
+    std::unique_ptr<SkCodec> codec = SkCodec::MakeFromData(skData, nullptr);
+    if (!codec)
+        return;
+    SkEncodedOrigin origin = codec->getOrigin();
     if (origin == SkEncodedOrigin::kTopLeft_SkEncodedOrigin)
         mImageData = SkImage::MakeFromEncoded(skData);
     else


### PR DESCRIPTION
If the image data passed to SkCodec::MakeFromData is not recognized as
image data the SkCodec::MakeFromData may return nullptr. Check for this
failure and return instead of crashing.