### PR TITLE
ignoring viewBox translation

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -964,7 +964,7 @@ void SVGDocumentImpl::RenderElement(const Element& element, const ColorMap& colo
 
     GraphicStyleImpl graphicStyle{};
     graphicStyle.transform = mRenderer->CreateTransform();
-    graphicStyle.transform->Translate(-1 * mViewBox[0], -1 * mViewBox[1]);
+   // graphicStyle.transform->Translate(-1 * mViewBox[0], -1 * mViewBox[1]);
     graphicStyle.transform->Scale(scale, scale);
 
     auto saveRestore = SaveRestoreHelper{mRenderer, graphicStyle};


### PR DESCRIPTION
if view-box coordinates are present in svg file , sometimes we will get as output blank file. to get rid of this , we can ignore translate of view-box.