### PR TITLE
support of tight bounding boxes for images or handling some glyphs wh…

### DIFF
--- a/svgnative/example/testSkia/TestSkia.cpp
+++ b/svgnative/example/testSkia/TestSkia.cpp
@@ -45,6 +45,17 @@ int main(int argc, char* const argv[])
 
     auto doc = std::unique_ptr<SVGNative::SVGDocument>(SVGNative::SVGDocument::CreateSVGDocument(svgInput.c_str(), renderer));
 
+    {
+        // make initially default canvas and compute the bounds , after computation make
+        // new canvas again of actual bounds.
+        auto skRasterSurface = SkSurface::MakeRasterN32Premul(doc->Width(), doc->Height());
+        auto skRasterCanvas = skRasterSurface->getCanvas();
+
+        renderer->SetSkCanvas(skRasterCanvas);
+        SVGNative::Rect bounds {0,0,0,0};
+        doc->GetBoundingBox(bounds);
+    }
+
     auto skRasterSurface = SkSurface::MakeRasterN32Premul(doc->Width(), doc->Height());
     auto skRasterCanvas = skRasterSurface->getCanvas();
 

--- a/svgnative/src/SVGDocument.cpp
+++ b/svgnative/src/SVGDocument.cpp
@@ -130,7 +130,10 @@ bool SVGDocument::GetBoundingBox(Rect& bounds)
 {
     if (!mDocument)
         return false;
-    return mDocument->GetBoundingBox(bounds);
+    bool bStatus = mDocument->GetBoundingBox(bounds);
+    if (bStatus && bounds.IsEmpty()== false)
+        mDocument->UpdateViewBox(bounds);
+    return bStatus;
 }
 
 bool SVGDocument::GetBoundingBox(const char *id, Rect& bounds)

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -1025,6 +1025,13 @@ bool SVGDocumentImpl::GetBoundingBox(const char* id, Rect& bound)
     return true;
 }
 
+void SVGDocumentImpl::UpdateViewBox(Rect& bounds)
+{
+    mViewBox[0] = bounds.x;
+    mViewBox[1] = bounds.y;
+    mViewBox[2] = bounds.width;
+    mViewBox[3] = bounds.height;
+}
 
 #ifdef DEBUG_API
 bool GetSubBoundingBoxes(std::vector<Rect>& bounds);

--- a/svgnative/src/SVGDocumentImpl.h
+++ b/svgnative/src/SVGDocumentImpl.h
@@ -198,7 +198,7 @@ public:
 
     bool GetBoundingBox(Rect& bounds);
     bool GetBoundingBox(const char* id, Rect& bounds);
-
+    void UpdateViewBox(Rect& bounds);
 #ifdef DEBUG_API
     bool GetSubBoundingBoxes(std::vector<Rect>& bounds);
     bool GetSubBoundingBoxes(const char* id, std::vector<Rect>& bounds);


### PR DESCRIPTION
…ich crops in output

To provide output in a tight bound box by computing the bounds of image and then draw a canvas of bounds size.
This change is necessary for that svg files having viewbox values are small (width & height) as compare to image bounds (width & height)

initially by using default canvas, we compute bounds of image. Then by using same bounds draw the required canvas again and draw the image on new canvas. it will ensure our image will fits correctly into new canvas.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
![xx](https://user-images.githubusercontent.com/90841856/170270234-3b4e1fb6-e9ba-4a40-8846-05bd62b5872b.svg)
