### PR TITLE
support number or percentage values for offset/opacity values 

### DIFF
--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -611,7 +611,7 @@ void SVGDocumentImpl::ParseFillProperties(FillStyleImpl& fillStyle, const Proper
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
             fillStyle.fillOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -703,7 +703,7 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
     {
         float miter{};
         // Miter must be bigger 1. Otherwise ignore.
-        if (SVGStringParser::ParseNumber(prop->second, miter) && miter >= 1)
+        if (SVGStringParser::ParseNumberOrPercentage(prop->second, miter) && miter >= 1)
             strokeStyle.miterLimit = miter;
     }
 
@@ -744,7 +744,7 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
             strokeStyle.strokeOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 }
@@ -756,7 +756,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
             graphicStyle.opacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -783,7 +783,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
             graphicStyle.stopOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -810,7 +810,7 @@ float SVGDocumentImpl::ParseColorStop(const XMLNode* node, std::vector<ColorStop
     // * Stops must be in the range [0.0, 1.0].
     float offset{};
     auto attr = node->GetAttribute(kOffsetAttr);
-    offset = (attr.found && SVGStringParser::ParseNumber(attr.value, offset)) ? offset : lastOffset;
+    offset = (attr.found && SVGStringParser::ParseNumberOrPercentage(attr.value, offset)) ? offset : lastOffset;
     offset = std::max<float>(lastOffset, offset);
     offset = std::min<float>(1.0, std::max<float>(0.0, offset));
 

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -611,7 +611,7 @@ void SVGDocumentImpl::ParseFillProperties(FillStyleImpl& fillStyle, const Proper
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
+        if (SVGStringParser::ParseNumber(prop->second, opacity))
             fillStyle.fillOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -703,7 +703,7 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
     {
         float miter{};
         // Miter must be bigger 1. Otherwise ignore.
-        if (SVGStringParser::ParseNumberOrPercentage(prop->second, miter) && miter >= 1)
+        if (SVGStringParser::ParseNumber(prop->second, miter) && miter >= 1)
             strokeStyle.miterLimit = miter;
     }
 
@@ -744,7 +744,7 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
+        if (SVGStringParser::ParseNumber(prop->second, opacity))
             strokeStyle.strokeOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 }
@@ -756,7 +756,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
+        if (SVGStringParser::ParseNumber(prop->second, opacity))
             graphicStyle.opacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -783,7 +783,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumberOrPercentage(prop->second, opacity))
+        if (SVGStringParser::ParseNumber(prop->second, opacity))
             graphicStyle.stopOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -810,7 +810,7 @@ float SVGDocumentImpl::ParseColorStop(const XMLNode* node, std::vector<ColorStop
     // * Stops must be in the range [0.0, 1.0].
     float offset{};
     auto attr = node->GetAttribute(kOffsetAttr);
-    offset = (attr.found && SVGStringParser::ParseNumberOrPercentage(attr.value, offset)) ? offset : lastOffset;
+    offset = (attr.found && SVGStringParser::ParseNumber(attr.value, offset)) ? offset : lastOffset;
     offset = std::max<float>(lastOffset, offset);
     offset = std::min<float>(1.0, std::max<float>(0.0, offset));
 

--- a/svgnative/src/SVGDocumentImpl.cpp
+++ b/svgnative/src/SVGDocumentImpl.cpp
@@ -611,7 +611,7 @@ void SVGDocumentImpl::ParseFillProperties(FillStyleImpl& fillStyle, const Proper
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseAlphaValue(prop->second, opacity))
             fillStyle.fillOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -744,7 +744,7 @@ void SVGDocumentImpl::ParseStrokeProperties(StrokeStyleImpl& strokeStyle, const 
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseAlphaValue(prop->second, opacity))
             strokeStyle.strokeOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 }
@@ -756,7 +756,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseAlphaValue(prop->second, opacity))
             graphicStyle.opacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -783,7 +783,7 @@ void SVGDocumentImpl::ParseGraphicsProperties(GraphicStyleImpl& graphicStyle, co
     if (prop != iterEnd)
     {
         float opacity{};
-        if (SVGStringParser::ParseNumber(prop->second, opacity))
+        if (SVGStringParser::ParseAlphaValue(prop->second, opacity))
             graphicStyle.stopOpacity = std::max<float>(0.0, std::min<float>(1.0, opacity));
     }
 
@@ -810,7 +810,7 @@ float SVGDocumentImpl::ParseColorStop(const XMLNode* node, std::vector<ColorStop
     // * Stops must be in the range [0.0, 1.0].
     float offset{};
     auto attr = node->GetAttribute(kOffsetAttr);
-    offset = (attr.found && SVGStringParser::ParseNumber(attr.value, offset)) ? offset : lastOffset;
+    offset = (attr.found && SVGStringParser::ParseAlphaValue(attr.value, offset)) ? offset : lastOffset;
     offset = std::max<float>(lastOffset, offset);
     offset = std::min<float>(1.0, std::max<float>(0.0, offset));
 

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -412,6 +412,22 @@ bool ParseNumber(const std::string& numberString, float& number)
     return !SkipOptWsp(pos, end);
 }
 
+bool ParseAlphaValue(const std::string& numberString, float& number)
+{
+    auto pos = numberString.begin();
+    auto end = numberString.end();
+
+    if (!SkipOptWsp(pos, end))
+        return false;
+    if (!ParseScientificNumber(pos, end, number))
+        return false;
+    if (pos < end && *pos == '%')
+    {
+        number = number/100.0f;
+    }
+    return !SkipOptWsp(pos, end);
+}
+
 bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptional /*= true*/)
 {
     auto pos = numberListString.begin();

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -424,6 +424,7 @@ bool ParseAlphaValue(const std::string& numberString, float& number)
     if (pos < end && *pos == '%')
     {
         number = number/100.0f;
+        pos++;
     }
     return !SkipOptWsp(pos, end);
 }

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -400,7 +400,7 @@ bool ParseLengthOrPercentage(const std::string& lengthString, float relDimension
     return !SkipOptWsp(pos, end);
 }
 
-bool ParseNumberOrPercentage(const std::string& numberString, float& number)
+bool ParseNumber(const std::string& numberString, float& number)
 {
     auto pos = numberString.begin();
     auto end = numberString.end();
@@ -409,11 +409,6 @@ bool ParseNumberOrPercentage(const std::string& numberString, float& number)
         return false;
     if (!ParseScientificNumber(pos, end, number))
         return false;
-    if (pos < end && *pos == '%')
-    {
-        number = number/100;
-        pos++;
-    }
     return !SkipOptWsp(pos, end);
 }
 

--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -400,7 +400,7 @@ bool ParseLengthOrPercentage(const std::string& lengthString, float relDimension
     return !SkipOptWsp(pos, end);
 }
 
-bool ParseNumber(const std::string& numberString, float& number)
+bool ParseNumberOrPercentage(const std::string& numberString, float& number)
 {
     auto pos = numberString.begin();
     auto end = numberString.end();
@@ -409,6 +409,11 @@ bool ParseNumber(const std::string& numberString, float& number)
         return false;
     if (!ParseScientificNumber(pos, end, number))
         return false;
+    if (pos < end && *pos == '%')
+    {
+        number = number/100;
+        pos++;
+    }
     return !SkipOptWsp(pos, end);
 }
 

--- a/svgnative/src/SVGStringParser.h
+++ b/svgnative/src/SVGStringParser.h
@@ -21,7 +21,7 @@ namespace SVGNative
 namespace SVGStringParser
 {
 bool ParseTransform(const std::string& transformString, Transform& matrix);
-bool ParseNumberOrPercentage(const std::string& numberString, float& number);
+bool ParseNumber(const std::string& numberString, float& number);
 bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptional = true);
 bool ParseListOfLengthOrPercentage(
     const std::string& lengthOrPercentageListString, float relDimensionLength, std::vector<float>& numberList, bool isAllOptional = true);

--- a/svgnative/src/SVGStringParser.h
+++ b/svgnative/src/SVGStringParser.h
@@ -21,7 +21,7 @@ namespace SVGNative
 namespace SVGStringParser
 {
 bool ParseTransform(const std::string& transformString, Transform& matrix);
-bool ParseNumber(const std::string& numberString, float& number);
+bool ParseNumberOrPercentage(const std::string& numberString, float& number);
 bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptional = true);
 bool ParseListOfLengthOrPercentage(
     const std::string& lengthOrPercentageListString, float relDimensionLength, std::vector<float>& numberList, bool isAllOptional = true);

--- a/svgnative/src/SVGStringParser.h
+++ b/svgnative/src/SVGStringParser.h
@@ -22,6 +22,7 @@ namespace SVGStringParser
 {
 bool ParseTransform(const std::string& transformString, Transform& matrix);
 bool ParseNumber(const std::string& numberString, float& number);
+bool ParseAlphaValue(const std::string& numberString, float& number);
 bool ParseListOfNumbers(const std::string& numberListString, std::vector<float>& numberList, bool isAllOptional = true);
 bool ParseListOfLengthOrPercentage(
     const std::string& lengthOrPercentageListString, float relDimensionLength, std::vector<float>& numberList, bool isAllOptional = true);

--- a/svgnative/test/properties.svg
+++ b/svgnative/test/properties.svg
@@ -24,9 +24,9 @@
     <line x1="5" y1="16" x2="145" y2="16" stroke="black" stroke-opacity="2e-1"/>
     <line x1="5" y1="19" x2="145" y2="19" stroke="black" stroke-opacity="   
     2e-1  "/>
+    <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="20%"/>
 
     <!-- stroke-opacity: negative tests -->
-    <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="20%"/>
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="2px"/>
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="2pc"/>
     <line x1="5" y1="22" x2="145" y2="22" stroke="black" stroke-opacity="2pt"/>
@@ -39,9 +39,9 @@
     <rect x="5" y="36" width="140" height="2" opacity="2e-1"/>
     <rect x="5" y="39" width="140" height="2" opacity="   
     2e-1  "/>
+    <rect x="5" y="40" width="140" height="2" opacity="20%"/>
 
     <!-- opacity: negative tests -->
-    <rect x="5" y="40" width="140" height="2" opacity="20%"/>
     <rect x="5" y="40" width="140" height="2" opacity="2px"/>
     <rect x="5" y="40" width="140" height="2" opacity="2pc"/>
     <rect x="5" y="40" width="140" height="2" opacity="2pt"/>
@@ -54,9 +54,9 @@
     <rect x="5" y="36" width="140" height="2" fill-opacity="2e-1"/>
     <rect x="5" y="39" width="140" height="2" fill-opacity="   
     2e-1  "/>
+    <rect x="5" y="42" width="140" height="2" fill-opacity="20%"/>
 
     <!-- fill-opacity: negative tests -->
-    <rect x="5" y="42" width="140" height="2" fill-opacity="20%"/>
     <rect x="5" y="42" width="140" height="2" fill-opacity="2px"/>
     <rect x="5" y="42" width="140" height="2" fill-opacity="2pc"/>
     <rect x="5" y="42" width="140" height="2" fill-opacity="2pt"/>

--- a/svgnative/test/properties.txt
+++ b/svgnative/test/properties.txt
@@ -57,7 +57,7 @@
                 stroke: {hasStroke: true width: 1 opacity: 0.2 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path M5,22 L145,22
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
-                stroke: {hasStroke: true width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
+                stroke: {hasStroke: true width: 1 opacity: 0.2 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path M5,22 L145,22
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: true width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
@@ -85,7 +85,7 @@
             [path Rect(5,39,140,2) opacity: 0.2
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
-            [path Rect(5,40,140,2)
+            [path Rect(5,40,140,2) opacity: 0.2
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path Rect(5,40,140,2)
@@ -116,7 +116,7 @@
                 fill: {hasFill: true winding: nonzero opacity: 0.2 paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path Rect(5,42,140,2)
-                fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+                fill: {hasFill: true winding: nonzero opacity: 0.2 paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: false width: 1 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path Rect(5,42,140,2)
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}


### PR DESCRIPTION
Support of Percentage values when specifies offset/opacity for stroke/fill properties 
Make a ParseNumber function generic, now work for both as a number or % values
Modified testcase which initially does not support % values
