### PR TITLE
Fix iOS/tvOS/watchOS platform support

### DIFF
--- a/svgnative/src/SVGNativeCWrapper.cpp
+++ b/svgnative/src/SVGNativeCWrapper.cpp
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
 #endif
 #ifdef USE_CG
 #include "svgnative/ports/cg/CGSVGRenderer.h"
-#include <ApplicationServices/ApplicationServices.h>
+#include <CoreServices/CoreServices.h>
 #include <CoreGraphics/CoreGraphics.h>
 #endif
 #ifdef USE_SKIA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The ApplicationServices is not available on those platform.

By replacing with CoreServices, I can sucessfully build on all Apple platforms:

+ macOS 12 SDK
+ iOS 15 SDK
+ tvOS 15 SDK
+ watchOS SDK 8

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/svg-native-viewer/issues/180

## Motivation and Context

Fix compile issue on iOS/tvOS/watchOS

## How Has This Been Tested?

Testing build using both CMake and Xcode geneted project

Note: I'm using the source code and a modified CMake script to support iOS/tvOS/watchOS. This repo can support for those mobile platforms as well, but this is another PR or issue, so I didn't link here.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6919743/181730495-2d01e87c-1b94-491c-899d-d9081d7957f6.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
