### PR TITLE
Allow trailing wsp for stroke-dasharray

### DIFF
--- a/svgnative/src/SVGStringParser.cpp
+++ b/svgnative/src/SVGStringParser.cpp
@@ -462,7 +462,7 @@ bool ParseListOfLengthOrPercentage(const std::string& lengthOrPercentageListStri
     {
         temp = pos;
         if (!SkipOptWspOrDelimiter(temp, end, isAllOptional))
-            return false;
+            return true;
 
         if (!ParseLengthOrPercentage(temp, end, relDimensionLength, number, isAllOptional))
             return false;

--- a/svgnative/src/ports/cg/CGSVGRenderer.cpp
+++ b/svgnative/src/ports/cg/CGSVGRenderer.cpp
@@ -233,6 +233,14 @@ void CGSVGRenderer::DrawPath(const Path& path, const GraphicStyle& graphicStyle,
         }
         CGContextSetMiterLimit(mContext, strokeStyle.miterLimit);
         CGContextSetLineWidth(mContext, strokeStyle.lineWidth);
+        if (!strokeStyle.dashArray.empty())
+        {
+            std::vector<CGFloat> dashArray;
+            std::for_each(strokeStyle.dashArray.begin(), strokeStyle.dashArray.end(), [&dashArray](auto& item) {
+                dashArray.push_back(static_cast<CGFloat>(item));
+            });
+            CGContextSetLineDash(mContext, strokeStyle.dashOffset, dashArray.data(), dashArray.size());
+        }
 
         CGContextBeginPath(mContext);
         CGContextAddPath(mContext, static_cast<const CGSVGPath&>(path).mPath);

--- a/svgnative/test/dash-array.svg
+++ b/svgnative/test/dash-array.svg
@@ -8,6 +8,7 @@
     0.2cm"/>
     <line x2="200" y1="35" y2="35" stroke="black" stroke-width="5" stroke-dasharray=".99e1.2e2.1e2.9.9"/>
     <line x2="200" y1="40" y2="40" stroke="black" stroke-width="5" stroke-dasharray="5% 10%"/>
+    <line x2="200" y1="45" y2="45" stroke="black" stroke-width="5" stroke-dasharray="20 10 "/>
 
     <!-- invalid values -->
     <line x2="200" y1="100" y2="100" stroke="black" stroke-width="5" stroke-dasharray="20, 10, 20,"/>

--- a/svgnative/test/dash-array.txt
+++ b/svgnative/test/dash-array.txt
@@ -25,6 +25,9 @@
             [path M0,40 L200,40
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 14.1 28.3 dashOffset: 0 paint: rgba(0,0,0,1)}]
+            [path M0,45 L200,45
+                fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
+                stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dash: 20 10 dashOffset: 0 paint: rgba(0,0,0,1)}]
             [path M0,100 L200,100
                 fill: {hasFill: true winding: nonzero paint: rgba(0,0,0,1)}
                 stroke: {hasStroke: true width: 5 cap: butt join: miter miter: 4 dashOffset: 0 paint: rgba(0,0,0,1)}]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow trailing wsp for stroke-dasharray

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

`stroke-dasharray="20 10   "` failed so far but trailing whitespaces are allowed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test added

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
